### PR TITLE
New reliability API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,15 @@ let dc1 = null;
 let dc2 = null;
 
 // Config options
-// iceServers: string[];
-// proxyServer?: ProxyServer;
-// enableIceTcp?: boolean;
-// portRangeBegin?: Number;
-// portRangeEnd?: Number;
-// iceTransportPolicy?: 'all' | 'relay';
+// export interface RtcConfig {
+//     iceServers: string[];
+//     proxyServer?: ProxyServer;
+//     enableIceTcp?: boolean;
+//     portRangeBegin?: number;
+//     portRangeEnd?: number;
+//     maxMessageSize?: number;
+//     iceTransportPolicy?: TransportPolicy;
+// }
 
 // "iceServers" option is an array of stun/turn server urls
 // Examples;

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ peer2.onDataChannel((dc) => {
 // export interface DataChannelInitConfig {
 //     protocol?: string;
 //     negotiated?: boolean;
+//     id?: number;
 //     ordered?: boolean;
 //     maxPacketLifeTime?: number;
 //     maxRetransmits?: number;

--- a/README.md
+++ b/README.md
@@ -89,13 +89,18 @@ peer2.onDataChannel((dc) => {
 
 // DataChannel Options
 // export interface DataChannelInitConfig {
-//     reliability: {
-//         type: ReliabilityType;
-//         unordered: boolean;
-//         rexmit: number;
+//     protocol?: string;
+//     negotiated?: boolean;
+//     ordered?: boolean;
+//     maxPacketLifeTime?: number;
+//     maxRetransmits?: number;
+//
+//     // Deprecated, use ordered, maxPacketLifeTime, and maxRetransmits
+//     reliability?: {
+//         type?: ReliabilityType;
+//         unordered?: boolean;
+//         rexmit?: number;
 //     }
-//     negotiated: boolean;
-//     protocol: string;
 // }
 dc1 = peer1.createDataChannel("test");
 dc1.onOpen(() => {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -43,14 +43,15 @@ export interface IceServer {
     relayType?: RelayType;
 }
 
+export type TransportPolicy = 'all' | 'relay';
 export interface RtcConfig {
     iceServers: (string | IceServer)[];
     proxyServer?: ProxyServer;
     enableIceTcp?: boolean;
-    portRangeBegin?: Number;
-    portRangeEnd?: Number;
-    maxMessageSize?: Number;
-    iceTransportPolicy?: 'all' | 'relay';
+    portRangeBegin?: number;
+    portRangeEnd?: number;
+    maxMessageSize?: number;
+    iceTransportPolicy?: TransportPolicy;
 }
 
 export const enum DescriptionType {
@@ -64,13 +65,19 @@ export const enum ReliabilityType {
 }
 
 export interface DataChannelInitConfig {
-    reliability: {
-        type: ReliabilityType;
-        unordered: boolean;
-        rexmit: number;
+    protocol?: string;
+    negotiated?: boolean;
+    id?: number;
+    ordered?: boolean;
+    maxPacketLifeTime?: number;
+    maxRetransmits?: number;
+
+    // Deprecated, use ordered, maxPacketLifeTime, and maxRetransmits
+    reliability?: {
+        type?: ReliabilityType;
+        unordered?: boolean;
+        rexmit?: number;
     }
-    negotiated: boolean;
-    protocol: string;
 }
 
 export interface SelectedCandidateInfo {

--- a/src/peer-connection-wrapper.cpp
+++ b/src/peer-connection-wrapper.cpp
@@ -94,7 +94,7 @@ PeerConnectionWrapper::PeerConnectionWrapper(const Napi::CallbackInfo &info) : N
 
                 rtcConfig.iceServers.emplace_back(
                     rtc::IceServer(iceServer.Get("hostname").As<Napi::String>(),
-                                   (uint16_t)iceServer.Get("port").As<Napi::Number>().Uint32Value(),
+                                   uint16_t(iceServer.Get("port").As<Napi::Number>().Uint32Value()),
                                    iceServer.Get("username").As<Napi::String>(),
                                    iceServer.Get("password").As<Napi::String>(),
                                    relayType));
@@ -104,7 +104,7 @@ PeerConnectionWrapper::PeerConnectionWrapper(const Napi::CallbackInfo &info) : N
                 rtcConfig.iceServers.emplace_back(
                     rtc::IceServer(
                         iceServer.Get("hostname").As<Napi::String>(),
-                        (uint16_t)iceServer.Get("port").As<Napi::Number>().Uint32Value()));
+                        uint16_t(iceServer.Get("port").As<Napi::Number>().Uint32Value())));
             }
         }
     }
@@ -363,7 +363,7 @@ Napi::Value PeerConnectionWrapper::createDataChannel(const Napi::CallbackInfo &i
                     Napi::TypeError::New(env, "Wrong Reliability Config (type)").ThrowAsJavaScriptException();
                     return info.Env().Null();
                 }
-                switch ((int)reliability.Get("type").As<Napi::Number>())
+                switch (reliability.Get("type").As<Napi::Number>().Uint32Value())
                 {
                 case 0:
                     init.reliability.type = rtc::Reliability::Type::Reliable;
@@ -397,7 +397,7 @@ Napi::Value PeerConnectionWrapper::createDataChannel(const Napi::CallbackInfo &i
                     Napi::TypeError::New(env, "Wrong Reliability Config (rexmit)").ThrowAsJavaScriptException();
                     return info.Env().Null();
                 }
-                switch ((int)reliability.Get("type").As<Napi::Number>())
+                switch (reliability.Get("type").As<Napi::Number>().Uint32Value())
                 {
                 case 1:
                     init.reliability.rexmit = reliability.Get("rexmit").As<Napi::Number>();

--- a/src/peer-connection-wrapper.cpp
+++ b/src/peer-connection-wrapper.cpp
@@ -315,6 +315,17 @@ Napi::Value PeerConnectionWrapper::createDataChannel(const Napi::CallbackInfo &i
         }
 
         Napi::Object initConfig = info[1].As<Napi::Object>();
+
+        if (!initConfig.Get("protocol").IsUndefined())
+        {
+            if (!initConfig.Get("protocol").IsString())
+            {
+                Napi::TypeError::New(env, "Wrong DataChannel Init Config (protocol)").ThrowAsJavaScriptException();
+                return info.Env().Null();
+            }
+            init.protocol = initConfig.Get("protocol").As<Napi::String>();
+        }
+
         if (!initConfig.Get("negotiated").IsUndefined())
         {
             if (!initConfig.Get("negotiated").IsBoolean())
@@ -325,14 +336,14 @@ Napi::Value PeerConnectionWrapper::createDataChannel(const Napi::CallbackInfo &i
             init.negotiated = initConfig.Get("negotiated").As<Napi::Boolean>();
         }
 
-        if (!initConfig.Get("protocol").IsUndefined())
+        if (!initConfig.Get("id").IsUndefined())
         {
-            if (!initConfig.Get("protocol").IsString())
+            if (!initConfig.Get("id").IsNumber())
             {
-                Napi::TypeError::New(env, "Wrong DataChannel Init Config (protocol)").ThrowAsJavaScriptException();
+                Napi::TypeError::New(env, "Wrong DataChannel Init Config (id)").ThrowAsJavaScriptException();
                 return info.Env().Null();
             }
-            init.protocol = initConfig.Get("protocol").As<Napi::String>();
+            init.id = uint16_t(initConfig.Get("id").As<Napi::Number>().Uint32Value());
         }
 
         // Deprecated reliability object, kept for retro-compatibility

--- a/src/peer-connection-wrapper.cpp
+++ b/src/peer-connection-wrapper.cpp
@@ -415,9 +415,15 @@ Napi::Value PeerConnectionWrapper::createDataChannel(const Napi::CallbackInfo &i
             if (!initConfig.Get("ordered").IsBoolean())
             {
                 Napi::TypeError::New(env, "Wrong DataChannel Init Config (ordered)").ThrowAsJavaScriptException();
-                    return info.Env().Null();
+                return info.Env().Null();
             }
             init.reliability.unordered = !initConfig.Get("ordered").As<Napi::Boolean>();
+        }
+
+        if(initConfig.Get("maxPacketLifeTime").IsNumber() && initConfig.Get("maxRetransmits").IsNumber())
+        {
+            Napi::TypeError::New(env, "Wrong DataChannel Init Config, maxPacketLifeTime and maxRetransmits are exclusive").ThrowAsJavaScriptException();
+            return info.Env().Null();
         }
 
         if (initConfig.Get("maxPacketLifeTime").IsNumber())

--- a/test/connectivity.js
+++ b/test/connectivity.js
@@ -6,6 +6,17 @@ nodeDataChannel.preload();
 let dc1 = null;
 let dc2 = null;
 
+// Config options
+// export interface RtcConfig {
+//     iceServers: string[];
+//     proxyServer?: ProxyServer;
+//     enableIceTcp?: boolean;
+//     portRangeBegin?: number;
+//     portRangeEnd?: number;
+//     maxMessageSize?: number;
+//     iceTransportPolicy?: TransportPolicy;
+// }
+//
 // "iceServers" option is an array of stun/turn server urls
 // Examples;
 // STUN Server Example          : stun:stun.l.google.com:19302
@@ -59,13 +70,12 @@ peer2.onDataChannel((dc) => {
 
 // DataChannel Options
 // export interface DataChannelInitConfig {
-//     reliability: {
-//         type: ReliabilityType;
-//         unordered: boolean;
-//         rexmit: number;
-//     }
-//     negotiated: boolean;
-//     protocol: string;
+//     protocol?: string;
+//     negotiated?: boolean;
+//     id?: number;
+//     ordered?: boolean;
+//     maxPacketLifeTime?: number;
+//     maxRetransmits?: number;
 // }
 dc1 = peer1.createDataChannel("test");
 dc1.onOpen(() => {


### PR DESCRIPTION
This PR suggests a new reliability API matching the browser one for [createDataChannel](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createDataChannel) as it would make development easier. It also adds `id` to the DataChannel init config, since it was missing.

The existing reliability object is kept for retro-compatibility, of course.