### PR TITLE
Update libdatachannel to v0.15.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ include(FetchContent)
 FetchContent_Declare(
     libdatachannel
     GIT_REPOSITORY https://github.com/paullouisageneau/libdatachannel.git
-    GIT_TAG "v0.14.4"
+    GIT_TAG "v0.15.1"
 )
 
 FetchContent_GetProperties(libdatachannel)


### PR DESCRIPTION
This PR updates libdatachannel to v0.15.1, in particular to fix a possible crash caused by a race condition on early close.