### PR TITLE
Update libdatachannel to v0.15.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ include(FetchContent)
 FetchContent_Declare(
     libdatachannel
     GIT_REPOSITORY https://github.com/paullouisageneau/libdatachannel.git
-    GIT_TAG "v0.15.1"
+    GIT_TAG "v0.15.2"
 )
 
 FetchContent_GetProperties(libdatachannel)


### PR DESCRIPTION
This PR updates libdatachannel to v0.15.2. The race condition wasn't properly fixed in v0.15.1, sorry :sweat_smile: 