### PR TITLE
Update libdatachannel to v0.15.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,11 @@ include(FetchContent)
 FetchContent_Declare(
     libdatachannel
     GIT_REPOSITORY https://github.com/paullouisageneau/libdatachannel.git
-    GIT_TAG "v0.15.5"
+    GIT_TAG "v0.15.6"
 )
+
+option(NO_MEDIA "Disable media transport support in libdatachannel" ON)
+option(NO_WEBSOCKET "Disable WebSocket support in libdatachannel" ON)
 
 FetchContent_GetProperties(libdatachannel)
 if(NOT libdatachannel)

--- a/README.md
+++ b/README.md
@@ -159,8 +159,8 @@ Build with libnice support
 
 Other Options
 ```sh
-> npm run install -- -DUSE_GNUTLS=1   # Use GNU TLS instead of OpenSSL (Default False)
-> npm run install -- -DUSE_SRTP=1   # Enable SRTP for media support ( Default False)
+> npm run install -- -DUSE_GNUTLS=1  # Use GnuTLS instead of OpenSSL (Default False)
+> npm run install -- -DUSE_NICE=1    # Use libnice instead of libjuice (Default False)
 ```
 
 ### Test


### PR DESCRIPTION
This PR updates libdatachannel to v0.15.6 (which solves a possible deadlock introduced in the previous version). It also changes the compilation parameters to make it lighter by disabling Media and WebSocket support.