### PR TITLE
Fix ThreadSafeCallback for Node.js 12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,8 +54,14 @@ set_target_properties(${PROJECT_NAME} PROPERTIES PREFIX "" SUFFIX ".node")
 
 target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_SOURCE_DIR}/node_modules/node-addon-api
-    ${CMAKE_SOURCE_DIR}/node_modules/napi-thread-safe-callback
     ${CMAKE_BINARY_DIR}/_deps/libdatachannel-src/include
+)
+
+# For compatibility with Node.js 12
+# This should be removed along with the napi-thread-safe-callback-cancellable dependency when dropping support at end-of-life
+target_compile_definitions(${PROJECT_NAME} PRIVATE -DLEGACY_NAPI_THREAD_SAFE_CALLBACK)
+target_include_directories(${PROJECT_NAME} PRIVATE
+    ${CMAKE_SOURCE_DIR}/node_modules/napi-thread-safe-callback-cancellable
 )
 
 set(LINK_LIBRARIES

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "cmake-js": "^6.2.1",
     "jest": "^27.2.5",
     "nan": "^2.15.0",
+    "napi-thread-safe-callback-cancellable": "^0.0.7",
     "node-addon-api": "^4.2.0",
     "prebuild": "^11.0.0"
   },

--- a/src/thread-safe-callback.cpp
+++ b/src/thread-safe-callback.cpp
@@ -1,5 +1,11 @@
 #include "thread-safe-callback.h"
 
+#ifdef LEGACY_NAPI_THREAD_SAFE_CALLBACK
+
+// Nothing to do
+
+#else
+
 const char* ThreadSafeCallback::CancelException::what() const throw()
 {
     return "ThreadSafeCallback cancelled";
@@ -58,4 +64,6 @@ void ThreadSafeCallback::callbackFunc(Napi::Env env,
     if (env && callback)
         callback.Call(context->Value(), args);
 }
+
+#endif
 

--- a/src/thread-safe-callback.h
+++ b/src/thread-safe-callback.h
@@ -1,6 +1,12 @@
 #ifndef THREAD_SAFE_CALLBACK_H
 #define THREAD_SAFE_CALLBACK_H
 
+#ifdef LEGACY_NAPI_THREAD_SAFE_CALLBACK
+
+#include "napi-thread-safe-callback.hpp"
+
+#else
+
 #include <napi.h>
 
 #include <vector>
@@ -44,6 +50,8 @@ private:
     Napi::Reference<Napi::Value> receiver;
     tsfn_t tsfn;
 };
+
+#endif // LEGACY_NAPI_THREAD_SAFE_CALLBACK
 
 #endif // THREAD_SAFE_CALLBACK_H
 


### PR DESCRIPTION
This PR fixes the regression with Node.js 12 introduced by https://github.com/murat-dogan/node-datachannel/pull/66

For the time being, a compile definition `LEGACY_NAPI_THREAD_SAFE_CALLBACK` makes the build fall back to a fork of `napi-thread-safe-callback` allowing cancellation like the custom `ThreadSafeCallback` implementation. It may be disabled or removed when Node.js 12 support is removed.

I think this temporary solution is fine as `Napi::TypedThreadSafeFunction` seems to behave weirdly with Node.js 12 (which will reach end-of-life in a couple months anyway), and as `napi-thread-safe-callback` doesn't seem maintained anymore.