### PR TITLE
Add missing states methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ TURN Server Example          : turn:USERNAME:PASSWORD@TURN_IP_OR_ADDRESS:PORT
 TURN Server Example (TCP)    : turn:USERNAME:PASSWORD@TURN_IP_OR_ADDRESS:PORT?transport=tcp
 TURN Server Example (TLS)    : turns:USERNAME:PASSWORD@TURN_IP_OR_ADDRESS:PORT
 
-``` 
+```
 
 **close: () => void**
 
@@ -179,7 +179,11 @@ export interface DataChannelInitConfig {
 export const enum ReliabilityType {
     Reliable = 0, Rexmit = 1, Timed = 2
 }
-``` 
+```
+**state: () => string**
+
+Get current state
+
 **signalingState: () => string**
 
 Get current signaling state
@@ -245,7 +249,7 @@ export interface SelectedCandidateInfo {
 
 **close: () => void**
 
-Close data channel 
+Close data channel
 
 **getLabel: () => string**
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ Local Candidate Callback
 
 State Change Callback
 
+**onSignalingStateChange: (state: (sdp: string) => void) => void**
+
+Signaling State Change Callback
+
 **onGatheringStateChange: (state: (sdp: string) => void) => void**
 
 Gathering State Change Callback

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -211,6 +211,7 @@ export class PeerConnection {
     onLocalDescription: (cb: (sdp: string, type: DescriptionType) => void) => void;
     onLocalCandidate: (cb: (candidate: string, mid: string) => void) => void;
     onStateChange: (cb: (state: string) => void) => void;
+    onSignalingStateChange: (state: (sdp: string) => void) => void;
     onGatheringStateChange: (state: (sdp: string) => void) => void;
     onDataChannel: (cb: (dc: DataChannel) => void) => void;
     onTrack: () => Track;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -134,7 +134,7 @@ export class Video {
     addH264Codec: (payloadType: Number, profile?: string) => void;
     addVP8Codec: (payloadType: Number) => void;
     addVP9Codec: (payloadType: Number) => void;
-    
+
     direction: () => Direction;
     generateSdp: (eol: string, addr: string, port: string) => string;
     mid: () => string;
@@ -205,6 +205,7 @@ export class PeerConnection {
     createDataChannel: (label: string, config?: DataChannelInitConfig) => DataChannel;
     addTrack: (media: Video | Audio) => Track;
     hasMedia: () => boolean;
+    state: () => string;
     signalingState: () => string;
     gatheringState: () => string;
     onLocalDescription: (cb: (sdp: string, type: DescriptionType) => void) => void;

--- a/src/peer-connection-wrapper.cpp
+++ b/src/peer-connection-wrapper.cpp
@@ -32,6 +32,7 @@ Napi::Object PeerConnectionWrapper::Init(Napi::Env env, Napi::Object exports)
             InstanceMethod("createDataChannel", &PeerConnectionWrapper::createDataChannel),
             InstanceMethod("addTrack", &PeerConnectionWrapper::addTrack),
             InstanceMethod("hasMedia", &PeerConnectionWrapper::hasMedia),
+            InstanceMethod("state", &PeerConnectionWrapper::state),
             InstanceMethod("signalingState", &PeerConnectionWrapper::signalingState),
             InstanceMethod("gatheringState", &PeerConnectionWrapper::gatheringState),
             InstanceMethod("onLocalDescription", &PeerConnectionWrapper::onLocalDescription),
@@ -887,6 +888,14 @@ Napi::Value PeerConnectionWrapper::hasMedia(const Napi::CallbackInfo &info)
 {
     Napi::Env env = info.Env();
     return Napi::Boolean::New(env, mRtcPeerConnPtr->hasMedia());
+}
+
+Napi::Value PeerConnectionWrapper::state(const Napi::CallbackInfo &info)
+{
+    Napi::Env env = info.Env();
+    std::ostringstream stream;
+    stream << mRtcPeerConnPtr->state();
+    return Napi::String::New(env, stream.str());
 }
 
 Napi::Value PeerConnectionWrapper::signalingState(const Napi::CallbackInfo &info)

--- a/src/peer-connection-wrapper.h
+++ b/src/peer-connection-wrapper.h
@@ -36,6 +36,7 @@ public:
   void onLocalDescription(const Napi::CallbackInfo &info);
   void onLocalCandidate(const Napi::CallbackInfo &info);
   void onStateChange(const Napi::CallbackInfo &info);
+  void onSignalingStateChange(const Napi::CallbackInfo &info);
   void onGatheringStateChange(const Napi::CallbackInfo &info);
   void onDataChannel(const Napi::CallbackInfo &info);
   void onTrack(const Napi::CallbackInfo &info);
@@ -62,6 +63,7 @@ private:
   std::unique_ptr<ThreadSafeCallback> mOnLocalDescriptionCallback = nullptr;
   std::unique_ptr<ThreadSafeCallback> mOnLocalCandidateCallback = nullptr;
   std::unique_ptr<ThreadSafeCallback> mOnStateChangeCallback = nullptr;
+  std::unique_ptr<ThreadSafeCallback> mOnSignalingStateChangeCallback = nullptr;
   std::unique_ptr<ThreadSafeCallback> mOnGatheringStateChangeCallback = nullptr;
   std::unique_ptr<ThreadSafeCallback> mOnDataChannelCallback = nullptr;
   std::unique_ptr<ThreadSafeCallback> mOnTrackCallback = nullptr;

--- a/src/peer-connection-wrapper.h
+++ b/src/peer-connection-wrapper.h
@@ -26,10 +26,11 @@ public:
   Napi::Value localDescription(const Napi::CallbackInfo &info);
   void addRemoteCandidate(const Napi::CallbackInfo &info);
   Napi::Value createDataChannel(const Napi::CallbackInfo &info);
-  Napi::Value addTrack(const Napi::CallbackInfo &info);  
-  Napi::Value hasMedia(const Napi::CallbackInfo &info); 
-  Napi::Value signalingState(const Napi::CallbackInfo &info); 
-  Napi::Value gatheringState(const Napi::CallbackInfo &info); 
+  Napi::Value addTrack(const Napi::CallbackInfo &info);
+  Napi::Value hasMedia(const Napi::CallbackInfo &info);
+  Napi::Value state(const Napi::CallbackInfo &info);
+  Napi::Value signalingState(const Napi::CallbackInfo &info);
+  Napi::Value gatheringState(const Napi::CallbackInfo &info);
 
   // Callbacks
   void onLocalDescription(const Napi::CallbackInfo &info);


### PR DESCRIPTION
This PR adds the  state getter and the signaling state callback, so all state-related methods are now exposed.