### PR TITLE
Fix the AudioWrapper constructor to be more like the VideoWrapper

### DIFF
--- a/src/media-audio-wrapper.cpp
+++ b/src/media-audio-wrapper.cpp
@@ -51,7 +51,7 @@ AudioWrapper::AudioWrapper(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Au
     rtc::Description::Direction dir = rtc::Description::Direction::SendOnly;
 
     // optional
-    if (length > 1)
+    if (length > 0)
     {
         if (!info[0].IsString())
         {
@@ -62,7 +62,7 @@ AudioWrapper::AudioWrapper(const Napi::CallbackInfo &info) : Napi::ObjectWrap<Au
     }
 
     // ootional
-    if (length > 2)
+    if (length > 1)
     {
         if (!info[1].IsString())
         {


### PR DESCRIPTION
Fixes issue https://github.com/murat-dogan/node-datachannel/issues/78 so that the direction can be properly set on `Audio` tracks