### PR TITLE
Add DataChannelStream to turn a data channel into a Node stream

### DIFF
--- a/lib/datachannel-stream.js
+++ b/lib/datachannel-stream.js
@@ -12,6 +12,7 @@ module.exports = class DataChannelStream extends stream.Duplex {
 
     constructor(rawChannel, streamOptions) {
         super({
+            allowHalfOpen: false, // Default to autoclose on end().
             ...streamOptions,
             objectMode: true // Preserve the string/buffer distinction (WebRTC treats them differently)
         });
@@ -67,9 +68,15 @@ module.exports = class DataChannelStream extends stream.Duplex {
         }
     }
 
-    _destroy() {
+    _final(callback) {
+        if (!this.allowHalfOpen) this.destroy();
+        callback(null);
+    }
+
+    _destroy(maybeErr, callback) {
         // When the stream is destroyed, we close the DataChannel.
         this._rawChannel.close();
+        callback(maybeErr);
     }
 
     get label() {

--- a/lib/datachannel-stream.js
+++ b/lib/datachannel-stream.js
@@ -1,0 +1,79 @@
+const stream = require('stream');
+
+/**
+ * Turns a node-datachannel DataChannel into a real Node.js stream, complete with buffering,
+ * backpressure (up to a point - if the buffer fills up, messages are dropped), and
+ * support for piping data elsewhere.
+ *
+ * Read & written data may be either UTF-8 strings or Buffers - this difference exists at
+ * the protocol level, and is preserved here throughout.
+ */
+module.exports = class DataChannelStream extends stream.Duplex {
+
+    constructor(rawChannel, streamOptions) {
+        super({
+            ...streamOptions,
+            objectMode: true // Preserve the string/buffer distinction (WebRTC treats them differently)
+        });
+
+        this._rawChannel = rawChannel;
+        this._readActive = true;
+
+        rawChannel.onMessage((msg) => {
+            if (!this._readActive) return; // If the buffer is full, drop messages.
+
+            // If the push is rejected, we pause reading until the next call to _read().
+            this._readActive = this.push(msg);
+        });
+
+        // When the DataChannel closes, the readable & writable ends close
+        rawChannel.onClosed(() => {
+            this.push(null);
+            this.destroy();
+        });
+
+        rawChannel.onError((errMsg) => {
+            this.destroy(new Error(`DataChannel error: ${errMsg}`));
+        });
+
+        // Buffer all writes until the DataChannel opens
+        if (!rawChannel.isOpen()) {
+            this.cork();
+            rawChannel.onOpen(() => this.uncork());
+        }
+    }
+
+    _read() {
+        // Stop dropping messages, if the buffer filling up meant we were doing so before.
+        this._readActive = true;
+    }
+
+    _write(chunk, encoding, callback) {
+        let sentOk;
+        if (Buffer.isBuffer(chunk)) {
+            sentOk = this._rawChannel.sendMessageBinary(chunk);
+        } else if (typeof chunk === 'string') {
+            sentOk = this._rawChannel.sendMessage(chunk);
+        } else {
+            const typeName = chunk.constructor.name || typeof chunk;
+            callback(new Error(`Cannot write ${typeName} to DataChannel stream`));
+            return;
+        }
+
+        if (sentOk) {
+            callback(null);
+        } else {
+            callback(new Error("Failed to write to DataChannel"));
+        }
+    }
+
+    _destroy() {
+        // When the stream is destroyed, we close the DataChannel.
+        this._rawChannel.close();
+    }
+
+    get label() {
+        return this._rawChannel.getLabel();
+    }
+
+}

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,3 +1,5 @@
+import * as stream from 'stream';
+
 export as namespace NodeDataChannel;
 
 // Enum in d.ts is tricky
@@ -219,4 +221,12 @@ export class PeerConnection {
     bytesReceived: () => number;
     rtt: () => number;
     getSelectedCandidatePair: () => { local: SelectedCandidateInfo, remote: SelectedCandidateInfo } | null;
+}
+
+export class DataChannelStream extends stream.Duplex {
+    constructor(
+        rawChannel: DataChannel,
+        options?: Omit<stream.DuplexOptions, 'objectMode'>
+    );
+    get label(): string;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,2 +1,4 @@
 const nodeDataChannel = require("../build/Release/node_datachannel.node");
 module.exports = nodeDataChannel;
+
+module.exports.DataChannelStream = require('./datachannel-stream');

--- a/package-lock.json
+++ b/package-lock.json
@@ -842,10 +842,9 @@
       }
     },
     "@types/node": {
-      "version": "17.0.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.19.tgz",
-      "integrity": "sha512-PfeQhvcMR4cPFVuYfBN4ifG7p9c+Dlh3yUZR6k+5yQK7wX3gDgVxBly4/WkBRs9x4dmcy1TVl08SY67wwtEvmA==",
-      "dev": true
+      "version": "17.0.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
     },
     "@types/prettier": {
       "version": "2.4.4",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "prebuild-install"
   ],
   "dependencies": {
+    "@types/node": "^17.0.21",
     "prebuild-install": "^7.0.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -185,7 +185,8 @@ describe('DataChannel streams', () => {
         expect(await clientResponsePromise).toBe("test message");
 
         clientChannel.close();
-        echoStream.destroy();
+        await new Promise((resolve) => echoStream.on('end', resolve));
+
         clientPeer.close();
         echoPeer.close();
     });

--- a/test/test.js
+++ b/test/test.js
@@ -146,3 +146,47 @@ describe('P2P', () => {
 
     });
 });
+
+function waitForGathering(peer) {
+    return new Promise((resolve) => {
+        peer.onGatheringStateChange((state) => {
+            if (state === 'complete') resolve();
+        });
+        // Handle race conditions where gathering has already completed
+        if (peer.gatheringState() === 'complete') resolve();
+    });
+}
+
+describe('DataChannel streams', () => {
+
+    test('can build an echo pipeline', async () => {
+        let clientPeer = new nodeDataChannel.PeerConnection("Client", { iceServers: [] });
+        let echoPeer = new nodeDataChannel.PeerConnection("Client", { iceServers: [] });
+
+        const echoStream = new nodeDataChannel.DataChannelStream(
+            echoPeer.createDataChannel("echo-channel")
+        );
+        echoStream.pipe(echoStream); // Echo all received data back to the client
+
+        await waitForGathering(echoPeer);
+
+        const { sdp: echoDescSdp, type: echoDescType } = echoPeer.localDescription();
+        clientPeer.setRemoteDescription(echoDescSdp, echoDescType);
+        await waitForGathering(clientPeer);
+
+        const { sdp: clientDescSdp, type: clientDescType } = clientPeer.localDescription();
+        echoPeer.setRemoteDescription(clientDescSdp, clientDescType);
+
+        const clientChannel = await new Promise((resolve) => clientPeer.onDataChannel(resolve));
+
+        const clientResponsePromise = new Promise((resolve) => clientChannel.onMessage(resolve));
+        clientChannel.sendMessage("test message");
+
+        expect(await clientResponsePromise).toBe("test message");
+
+        clientChannel.close();
+        echoStream.destroy();
+        clientPeer.close();
+        echoPeer.close();
+    });
+});


### PR DESCRIPTION
Fixes #81

This exposes a DataChannelStream export, which takes a DataChannel (and optionally any Duplex stream options) and returns a standard Node.js Duplex stream.

There's a test included here, which:

* Creates two peers: a client peer & an echo peer
* Creates a data channel for the echo peer, and wraps that as a DataChannelStream
* Pipes that stream back into itself (making the channel echo all input)
* Sends a message from the client peer on that channel
* Checks that the message is echoed back

~~This is marked as a draft, because shutdown still isn't working quite as expected, and I'm not sure why...~~

~~Right now this test does work, but I think the `echoStream.destroy()` shouldn't be necessary - instead either the `clientChannel.close()` or `clientPeer.close()` should result in the echo client's `rawChannel.onClosed()` callback firing (i.e. closing on one end of the connection should fire a close event on channels at the other end) which would destroy the stream to clean everything up automatically.~~

~~That callback never seems to fire at all, which is why we have to destroy the stream manually right now (without this, Jest complaints that various TCP handles are still open).~~

~~Is that assumption wrong? How are WebRTC clients supposed to signal connection shutdown to the remote end?~~