### PR TITLE
Expose the DataChannel id and protocol as dc.getId() and dc.getProtocol()

### DIFF
--- a/lib/datachannel-stream.js
+++ b/lib/datachannel-stream.js
@@ -83,4 +83,12 @@ module.exports = class DataChannelStream extends stream.Duplex {
         return this._rawChannel.getLabel();
     }
 
+    get id() {
+        return this._rawChannel.getId();
+    }
+
+    get protocol() {
+        return this._rawChannel.getProtocol();
+    }
+
 }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -183,6 +183,7 @@ export class DataChannel {
     close: () => void;
     getLabel: () => string;
     getId: () => number;
+    getProtocol: () => string;
     sendMessage: (msg: string) => boolean;
     sendMessageBinary: (buffer: Buffer) => boolean;
     isOpen: () => boolean;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -182,6 +182,7 @@ export class Track {
 export class DataChannel {
     close: () => void;
     getLabel: () => string;
+    getId: () => number;
     sendMessage: (msg: string) => boolean;
     sendMessageBinary: (buffer: Buffer) => boolean;
     isOpen: () => boolean;

--- a/src/data-channel-wrapper.cpp
+++ b/src/data-channel-wrapper.cpp
@@ -20,6 +20,7 @@ Napi::Object DataChannelWrapper::Init(Napi::Env env, Napi::Object exports)
         {
             InstanceMethod("close", &DataChannelWrapper::close),
             InstanceMethod("getLabel", &DataChannelWrapper::getLabel),
+            InstanceMethod("getId", &DataChannelWrapper::getId),
             InstanceMethod("sendMessage", &DataChannelWrapper::sendMessage),
             InstanceMethod("sendMessageBinary", &DataChannelWrapper::sendMessageBinary),
             InstanceMethod("isOpen", &DataChannelWrapper::isOpen),
@@ -91,6 +92,17 @@ Napi::Value DataChannelWrapper::getLabel(const Napi::CallbackInfo &info)
     }
 
     return Napi::String::New(info.Env(), mDataChannelPtr->label());
+}
+
+Napi::Value DataChannelWrapper::getId(const Napi::CallbackInfo &info)
+{
+    if (!mDataChannelPtr)
+    {
+        Napi::Error::New(info.Env(), "It seems data-channel is destroyed!").ThrowAsJavaScriptException();
+        return info.Env().Null();
+    }
+
+    return Napi::Number::New(info.Env(), mDataChannelPtr->id());
 }
 
 Napi::Value DataChannelWrapper::sendMessage(const Napi::CallbackInfo &info)

--- a/src/data-channel-wrapper.cpp
+++ b/src/data-channel-wrapper.cpp
@@ -21,6 +21,7 @@ Napi::Object DataChannelWrapper::Init(Napi::Env env, Napi::Object exports)
             InstanceMethod("close", &DataChannelWrapper::close),
             InstanceMethod("getLabel", &DataChannelWrapper::getLabel),
             InstanceMethod("getId", &DataChannelWrapper::getId),
+            InstanceMethod("getProtocol", &DataChannelWrapper::getProtocol),
             InstanceMethod("sendMessage", &DataChannelWrapper::sendMessage),
             InstanceMethod("sendMessageBinary", &DataChannelWrapper::sendMessageBinary),
             InstanceMethod("isOpen", &DataChannelWrapper::isOpen),
@@ -103,6 +104,17 @@ Napi::Value DataChannelWrapper::getId(const Napi::CallbackInfo &info)
     }
 
     return Napi::Number::New(info.Env(), mDataChannelPtr->id());
+}
+
+Napi::Value DataChannelWrapper::getProtocol(const Napi::CallbackInfo &info)
+{
+    if (!mDataChannelPtr)
+    {
+        Napi::Error::New(info.Env(), "It seems data-channel is destroyed!").ThrowAsJavaScriptException();
+        return info.Env().Null();
+    }
+
+    return Napi::String::New(info.Env(), mDataChannelPtr->protocol());
 }
 
 Napi::Value DataChannelWrapper::sendMessage(const Napi::CallbackInfo &info)

--- a/src/data-channel-wrapper.h
+++ b/src/data-channel-wrapper.h
@@ -23,6 +23,7 @@ public:
   // Functions
   void close(const Napi::CallbackInfo &info);
   Napi::Value getLabel(const Napi::CallbackInfo &info);
+  Napi::Value getId(const Napi::CallbackInfo &info);
   Napi::Value sendMessage(const Napi::CallbackInfo &info);
   Napi::Value sendMessageBinary(const Napi::CallbackInfo &info);
   Napi::Value isOpen(const Napi::CallbackInfo &info);

--- a/src/data-channel-wrapper.h
+++ b/src/data-channel-wrapper.h
@@ -24,6 +24,7 @@ public:
   void close(const Napi::CallbackInfo &info);
   Napi::Value getLabel(const Napi::CallbackInfo &info);
   Napi::Value getId(const Napi::CallbackInfo &info);
+  Napi::Value getProtocol(const Napi::CallbackInfo &info);
   Napi::Value sendMessage(const Napi::CallbackInfo &info);
   Napi::Value sendMessageBinary(const Napi::CallbackInfo &info);
   Napi::Value isOpen(const Napi::CallbackInfo &info);

--- a/test/test.js
+++ b/test/test.js
@@ -26,6 +26,8 @@ describe('PeerConnection Classes', () => {
         let peer = new nodeDataChannel.PeerConnection("Peer", { iceServers: ["stun:stun.l.google.com:19302"] });
         let dc = peer.createDataChannel('test');
         expect(dc).toBeDefined();
+        expect(dc.getId()).toBeDefined();
+        expect(dc.getLabel()).toBe('test');
         expect(dc.onOpen).toBeDefined();
         expect(dc.onMessage).toBeDefined();
 

--- a/test/test.js
+++ b/test/test.js
@@ -24,9 +24,10 @@ describe('PeerConnection Classes', () => {
 
     test('Create Data Channel', () => {
         let peer = new nodeDataChannel.PeerConnection("Peer", { iceServers: ["stun:stun.l.google.com:19302"] });
-        let dc = peer.createDataChannel('test');
+        let dc = peer.createDataChannel('test', { protocol: 'test-protocol' });
         expect(dc).toBeDefined();
         expect(dc.getId()).toBeDefined();
+        expect(dc.getProtocol()).toBe('test-protocol');
         expect(dc.getLabel()).toBe('test');
         expect(dc.onOpen).toBeDefined();
         expect(dc.onMessage).toBeDefined();


### PR DESCRIPTION
I've just followed the implementation of `getLabel()` exactly here to expose two more channel properties that are useful but weren't previously accessible. Hopefully the implementation is self-explanatory!