### PR TITLE
Properly handle DataChannelStream write exceptions

### DIFF
--- a/lib/datachannel-stream.js
+++ b/lib/datachannel-stream.js
@@ -51,14 +51,18 @@ module.exports = class DataChannelStream extends stream.Duplex {
 
     _write(chunk, encoding, callback) {
         let sentOk;
-        if (Buffer.isBuffer(chunk)) {
-            sentOk = this._rawChannel.sendMessageBinary(chunk);
-        } else if (typeof chunk === 'string') {
-            sentOk = this._rawChannel.sendMessage(chunk);
-        } else {
-            const typeName = chunk.constructor.name || typeof chunk;
-            callback(new Error(`Cannot write ${typeName} to DataChannel stream`));
-            return;
+
+        try {
+            if (Buffer.isBuffer(chunk)) {
+                sentOk = this._rawChannel.sendMessageBinary(chunk);
+            } else if (typeof chunk === 'string') {
+                sentOk = this._rawChannel.sendMessage(chunk);
+            } else {
+                const typeName = chunk.constructor.name || typeof chunk;
+                throw new Error(`Cannot write ${typeName} to DataChannel stream`);
+            }
+        } catch (err) {
+            return callback(err);
         }
 
         if (sentOk) {


### PR DESCRIPTION
Tiny fix for my own bug: I didn't realise before that although `sendMessage()` returns false when a write fails, it can also throw synchronous exceptions, e.g. if the channel is closed.

This catches synchronous errors from those calls, so that these are correctly passed to the `_write` callback (to be reported to downstream code as stream `error` events) rather than being uncatchable exceptions that crash the process.