### PR TITLE
fix windows version

### DIFF
--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-windows-x64:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x]
@@ -39,7 +39,7 @@ jobs:
           CI: true
 
   build-windows-x86:
-    runs-on: windows-latest
+    runs-on: windows-2019
     strategy:
       matrix:
         node_version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x]


### PR DESCRIPTION
We was using `windows-latest`. It points windows 2022 now. For x86 build we got error;
```
Generating Code...
     Creating library D:/a/node-datachannel/node-datachannel/build/Release/node_datachannel.lib and object D:/a/node-datachannel/node-datachannel/build/Release/node_datachannel.exp
LINK : warning LNK4199: /DELAYLOAD:NODE.EXE ignored; no imports found from NODE.EXE [D:\a\node-datachannel\node-datachannel\build\node_datachannel.vcxproj]
media-video-wrapper.obj : error LNK2001: unresolved external symbol napi_get_last_error_info [D:\a\node-datachannel\node-datachannel\build\node_datachannel.vcxproj]
data-channel-wrapper.obj : error LNK2001: unresolved external symbol napi_get_last_error_info [D:\a\node-datachannel\node-datachannel\build\node_datachannel.vcxproj]
peer-connection-wrapper.obj : error LNK2001: unresolved external symbol napi_get_last_error_info [D:\a\node-datachannel\node-datachannel\build\node_datachannel.vcxproj]
main.obj : error LNK2001: unresolved external symbol napi_get_last_error_info [D:\a\node-datachannel\node-datachannel\build\node_datachannel.vcxproj]
rtc-wrapper.obj : error LNK2001: unresolved external symbol napi_get_last_error_info [D:\a\node-datachannel\node-datachannel\build\node_datachannel.vcxproj]
```

Compiles on Windows 2019.

> There is no problem for x64 builds on both windows version.