### PR TITLE
Fix some small issues in media track types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -165,7 +165,6 @@ export class Track {
     sendMessageBinary: (buffer: Buffer) => boolean;
     isOpen: () => boolean;
     isClosed: () => boolean;
-    availableAmount: () => Number;
     bufferedAmount: () => Number;
     maxMessageSize: () => Number;
     setBufferedAmountLowThreshold: (newSize: Number) => void;
@@ -174,9 +173,7 @@ export class Track {
     onOpen: (cb: () => void) => void;
     onClosed: (cb: () => void) => void;
     onError: (cb: (err: string) => void) => void;
-    onAvailable: (cb: () => void) => void;
-    onBufferedAmountLow: (cb: () => void) => void;
-    onMessage: (cb: (msg: string | Buffer) => void) => void;
+    onMessage: (cb: (msg: Buffer) => void) => void;
 }
 
 export class DataChannel {
@@ -187,14 +184,12 @@ export class DataChannel {
     sendMessage: (msg: string) => boolean;
     sendMessageBinary: (buffer: Buffer) => boolean;
     isOpen: () => boolean;
-    availableAmount: () => Number;
     bufferedAmount: () => Number;
     maxMessageSize: () => Number;
     setBufferedAmountLowThreshold: (newSize: Number) => void;
     onOpen: (cb: () => void) => void;
     onClosed: (cb: () => void) => void;
     onError: (cb: (err: string) => void) => void;
-    onAvailable: (cb: () => void) => void;
     onBufferedAmountLow: (cb: () => void) => void;
     onMessage: (cb: (msg: string | Buffer) => void) => void;
 }
@@ -218,7 +213,7 @@ export class PeerConnection {
     onSignalingStateChange: (state: (sdp: string) => void) => void;
     onGatheringStateChange: (state: (sdp: string) => void) => void;
     onDataChannel: (cb: (dc: DataChannel) => void) => void;
-    onTrack: () => Track;
+    onTrack: (cb: (track: Track) => void) => void;
     bytesSent: () => number;
     bytesReceived: () => number;
     rtt: () => number;


### PR DESCRIPTION
Some small issues I noticed using in the TypeScript types recently:

* The `onTrack` method should take a callback, it doesn't immediately return a track
* `onAvailable` and `availableAmount` don't exist anywhere since https://github.com/murat-dogan/node-datachannel/commit/926724198fe7f38f67bf68abf9264f5f2a2a3159
* `onBufferedAmountLow` [doesn't exist](https://github.com/murat-dogan/node-datachannel/blob/master/src/media-track-wrapper.h#L35-L39) for media tracks
* As far as I can tell (not 100% sure) `onMessage` can only ever return Buffer data for media tracks - string media data isn't really meaningful (unlike datachannels, where strings and buffers are handled differently at the protocol level).