### PR TITLE
Fix invalid std::optional access

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -202,7 +202,7 @@ export class PeerConnection {
     close: () => void;
     setLocalDescription: (type?: DescriptionType) => void;
     setRemoteDescription: (sdp: string, type: DescriptionType) => void;
-    localDescription: () => { type: string; sdp: string };
+    localDescription: () => { type: string; sdp: string } | null;
     addRemoteCandidate: (candidate: string, mid: string) => void;
     createDataChannel: (label: string, config?: DataChannelInitConfig) => DataChannel;
     addTrack: (media: Video | Audio) => Track;

--- a/src/peer-connection-wrapper.cpp
+++ b/src/peer-connection-wrapper.cpp
@@ -355,6 +355,11 @@ Napi::Value PeerConnectionWrapper::localDescription(const Napi::CallbackInfo &in
     Napi::Env env = info.Env();
     std::optional<rtc::Description> desc = mRtcPeerConnPtr->localDescription();
 
+    // Return JS null if no description
+    if(!desc.has_value()) {
+        return env.Null();
+    }
+
     Napi::Object obj = Napi::Object::New(env);
     obj.Set("type", desc->typeString());
     obj.Set("sdp", desc.value());


### PR DESCRIPTION
If the local description wasn't set, you'd get an invalid std::optional access upon trying to read it.