### PR TITLE
Cleanup Type Declaration Syntax

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -103,124 +103,124 @@ export const enum Direction {
 }
 
 export class RtcpReceivingSession {
-    requestBitrate: (bitRate: number) => void;
-    requestKeyframe: () => boolean;
+    requestBitrate(bitRate: number): void;
+    requestKeyframe(): boolean;
 }
 
 export class Audio {
     constructor(mid: string, dir: Direction);
-    addAudioCodec: (payloadType: number, codec: string, profile?: string) => void;
-    addOpusCodec: (payloadType: number, profile?: string) => string;
+    addAudioCodec(payloadType: number, codec: string, profile?: string): void;
+    addOpusCodec(payloadType: number, profile?: string): string;
 
-    direction: () => Direction;
-    generateSdp: (eol: string, addr: string, port: number) => string;
-    mid: () => string;
-    setDirection: (dir: Direction) => void;
-    description: () => string;
-    removeFormat: (fmt: string) => void;
-    addSSRC: (ssrc: number, name?: string, msid?: string, trackID?: string) => void;
-    removeSSRC: (ssrc: number) => void;
-    replaceSSRC: (oldSsrc: number, ssrc: number, name?: string, msid?: string, trackID?: string) => void;
-    hasSSRC: (ssrc: number) => boolean;
-    getSSRCs: () => number[];
-    getCNameForSsrc: (ssrc: number) => string;
-    setBitrate: (bitRate: number) => void;
-    getBitrate: () => number;
-    hasPayloadType: (payloadType: number) => boolean;
-    addRTXCodec: (payloadType: number, originalPayloadType: number, clockRate: number) => void;
-    addRTPMap: () => void;
-    parseSdpLine: (line: string) => void;
+    direction(): Direction;
+    generateSdp(eol: string, addr: string, port: number): string;
+    mid(): string;
+    setDirection(dir: Direction): void;
+    description(): string;
+    removeFormat(fmt: string): void;
+    addSSRC(ssrc: number, name?: string, msid?: string, trackID?: string): void;
+    removeSSRC(ssrc: number): void;
+    replaceSSRC(oldSsrc: number, ssrc: number, name?: string, msid?: string, trackID?: string): void;
+    hasSSRC(ssrc: number): boolean;
+    getSSRCs(): number[];
+    getCNameForSsrc(ssrc: number): string;
+    setBitrate(bitRate: number): void;
+    getBitrate(): number;
+    hasPayloadType(payloadType: number): boolean;
+    addRTXCodec(payloadType: number, originalPayloadType: number, clockRate: number): void;
+    addRTPMap(): void;
+    parseSdpLine(line: string): void;
 }
 
 export class Video {
     constructor(mid: string, dir: Direction);
-    addVideoCodec: (payloadType: number, codec: string, profile?: string) => void;
-    addH264Codec: (payloadType: number, profile?: string) => void;
-    addVP8Codec: (payloadType: number) => void;
-    addVP9Codec: (payloadType: number) => void;
+    addVideoCodec(payloadType: number, codec: string, profile?: string): void;
+    addH264Codec(payloadType: number, profile?: string): void;
+    addVP8Codec(payloadType: number): void;
+    addVP9Codec(payloadType: number): void;
 
-    direction: () => Direction;
-    generateSdp: (eol: string, addr: string, port: number) => string;
-    mid: () => string;
-    setDirection: (dir: Direction) => void;
-    description: () => string;
-    removeFormat: (fmt: string) => void;
-    addSSRC: (ssrc: number, name?: string, msid?: string, trackID?: string) => void;
-    removeSSRC: (ssrc: number) => void;
-    replaceSSRC: (oldSsrc: number, ssrc: number, name?: string, msid?: string, trackID?: string) => void;
-    hasSSRC: (ssrc: number) => boolean;
-    getSSRCs: () => number[];
-    getCNameForSsrc: (ssrc: number) => string;
-    setBitrate: (bitRate: number) => void;
-    getBitrate: () => number;
-    hasPayloadType: (payloadType: number) => boolean;
-    addRTXCodec: (payloadType: number, originalPayloadType: number, clockRate: number) => void;
-    addRTPMap: () => void;
-    parseSdpLine: (line: string) => void;
+    direction(): Direction;
+    generateSdp(eol: string, addr: string, port: number): string;
+    mid(): string;
+    setDirection(dir: Direction): void;
+    description(): string;
+    removeFormat(fmt: string): void;
+    addSSRC(ssrc: number, name?: string, msid?: string, trackID?: string): void;
+    removeSSRC(ssrc: number): void;
+    replaceSSRC(oldSsrc: number, ssrc: number, name?: string, msid?: string, trackID?: string): void;
+    hasSSRC(ssrc: number): boolean;
+    getSSRCs(): number[];
+    getCNameForSsrc(ssrc: number): string;
+    setBitrate(bitRate: number): void;
+    getBitrate(): number;
+    hasPayloadType(payloadType: number): boolean;
+    addRTXCodec(payloadType: number, originalPayloadType: number, clockRate: number): void;
+    addRTPMap(): void;
+    parseSdpLine(line: string): void;
 }
 
 export class Track {
-    direction: () => Direction;
-    mid: () => string;
-    type: () => string;
-    close: () => void;
-    sendMessage: (msg: string) => boolean;
-    sendMessageBinary: (buffer: Buffer) => boolean;
-    isOpen: () => boolean;
-    isClosed: () => boolean;
-    bufferedAmount: () => number;
-    maxMessageSize: () => number;
-    setBufferedAmountLowThreshold: (newSize: number) => void;
-    requestKeyframe: () => boolean;
-    setMediaHandler: (handler: RtcpReceivingSession) => void;
-    onOpen: (cb: () => void) => void;
-    onClosed: (cb: () => void) => void;
-    onError: (cb: (err: string) => void) => void;
-    onMessage: (cb: (msg: Buffer) => void) => void;
+    direction(): Direction;
+    mid(): string;
+    type(): string;
+    close(): void;
+    sendMessage(msg: string): boolean;
+    sendMessageBinary(buffer: Buffer): boolean;
+    isOpen(): boolean;
+    isClosed(): boolean;
+    bufferedAmount(): number;
+    maxMessageSize(): number;
+    setBufferedAmountLowThreshold(newSize: number): void;
+    requestKeyframe(): boolean;
+    setMediaHandler(handler: RtcpReceivingSession): void;
+    onOpen(cb: () => void): void;
+    onClosed(cb: () => void): void;
+    onError(cb: (err: string) => void): void;
+    onMessage(cb: (msg: Buffer) => void): void;
 }
 
 export class DataChannel {
-    close: () => void;
-    getLabel: () => string;
-    getId: () => number;
-    getProtocol: () => string;
-    sendMessage: (msg: string) => boolean;
-    sendMessageBinary: (buffer: Buffer) => boolean;
-    isOpen: () => boolean;
-    bufferedAmount: () => number;
-    maxMessageSize: () => number;
-    setBufferedAmountLowThreshold: (newSize: number) => void;
-    onOpen: (cb: () => void) => void;
-    onClosed: (cb: () => void) => void;
-    onError: (cb: (err: string) => void) => void;
-    onBufferedAmountLow: (cb: () => void) => void;
-    onMessage: (cb: (msg: string | Buffer) => void) => void;
+    close(): void;
+    getLabel(): string;
+    getId(): number;
+    getProtocol(): string;
+    sendMessage(msg: string): boolean;
+    sendMessageBinary(buffer: Buffer): boolean;
+    isOpen(): boolean;
+    bufferedAmount(): number;
+    maxMessageSize(): number;
+    setBufferedAmountLowThreshold(newSize: number): void;
+    onOpen(cb: () => void): void;
+    onClosed(cb: () => void): void;
+    onError(cb: (err: string) => void): void;
+    onBufferedAmountLow(cb: () => void): void;
+    onMessage(cb: (msg: string | Buffer) => void): void;
 }
 
 export class PeerConnection {
     constructor(peerName: string, config: RtcConfig);
-    close: () => void;
-    setLocalDescription: (type?: DescriptionType) => void;
-    setRemoteDescription: (sdp: string, type: DescriptionType) => void;
-    localDescription: () => { type: string; sdp: string } | null;
-    addRemoteCandidate: (candidate: string, mid: string) => void;
-    createDataChannel: (label: string, config?: DataChannelInitConfig) => DataChannel;
-    addTrack: (media: Video | Audio) => Track;
-    hasMedia: () => boolean;
-    state: () => string;
-    signalingState: () => string;
-    gatheringState: () => string;
-    onLocalDescription: (cb: (sdp: string, type: DescriptionType) => void) => void;
-    onLocalCandidate: (cb: (candidate: string, mid: string) => void) => void;
-    onStateChange: (cb: (state: string) => void) => void;
-    onSignalingStateChange: (cb: (state: string) => void) => void;
-    onGatheringStateChange: (cb: (state: string) => void) => void;
-    onDataChannel: (cb: (dc: DataChannel) => void) => void;
-    onTrack: (cb: (track: Track) => void) => void;
-    bytesSent: () => number;
-    bytesReceived: () => number;
-    rtt: () => number;
-    getSelectedCandidatePair: () => { local: SelectedCandidateInfo; remote: SelectedCandidateInfo } | null;
+    close(): void;
+    setLocalDescription(type?: DescriptionType): void;
+    setRemoteDescription(sdp: string, type: DescriptionType): void;
+    localDescription(): { type: string; sdp: string } | null;
+    addRemoteCandidate(candidate: string, mid: string): void;
+    createDataChannel(label: string, config?: DataChannelInitConfig): DataChannel;
+    addTrack(media: Video | Audio): Track;
+    hasMedia(): boolean;
+    state(): string;
+    signalingState(): string;
+    gatheringState(): string;
+    onLocalDescription(cb: (sdp: string, type: DescriptionType) => void): void;
+    onLocalCandidate(cb: (candidate: string, mid: string) => void): void;
+    onStateChange(cb: (state: string) => void): void;
+    onSignalingStateChange(cb: (state: string) => void): void;
+    onGatheringStateChange(cb: (state: string) => void): void;
+    onDataChannel(cb: (dc: DataChannel) => void): void;
+    onTrack(cb: (track: Track) => void): void;
+    bytesSent(): number;
+    bytesReceived(): number;
+    rtt(): number;
+    getSelectedCandidatePair(): { local: SelectedCandidateInfo; remote: SelectedCandidateInfo } | null;
 }
 
 export class DataChannelStream extends stream.Duplex {


### PR DESCRIPTION
The previous syntax implied that the class methods provided by node-datachannel were being set via properties on each class instance. The syntax in this pull request better reflects the method's presence on the class prototypes, and is consistent with the automatically generated type declarations for normal class methods in TypeScript.

Previous:
```ts
export class RtcpReceivingSession {
    requestBitrate: (bitRate: number) => void;
    requestKeyframe: () => boolean;
}
```

New:
```ts
export class RtcpReceivingSession {
    requestBitrate: (bitRate: number) => void;
    requestKeyframe: () => boolean;
}
```