### PR TITLE
Refactor cleanup on close to prevent JS callbacks after close()

### DIFF
--- a/src/peer-connection-wrapper.h
+++ b/src/peer-connection-wrapper.h
@@ -55,8 +55,6 @@ private:
   static std::unordered_set<PeerConnectionWrapper *> instances;
 
   void doClose();
-  void cleanCbsAndEraseInstance();
-  bool mDoCloseFlag = false;
 
   std::string mPeerName;
   std::unique_ptr<rtc::PeerConnection> mRtcPeerConnPtr = nullptr;

--- a/test/test.js
+++ b/test/test.js
@@ -108,15 +108,6 @@ describe('P2P', () => {
             dc2.close();
             peer1.close();
             peer2.close();
-
-            // Fee memory
-            dc1 = null;
-            dc2 = null;
-            peer1 = null;
-            peer2 = null;
-
-            // Cleanup Threads
-            nodeDataChannel.cleanup();
         }, 10 * 1000);
 
         setTimeout(() => {
@@ -186,4 +177,9 @@ describe('DataChannel streams', () => {
         clientPeer.close();
         echoPeer.close();
     });
+});
+
+afterAll(() => {
+    // Properly cleanup so Jest does not complain about asynchronous operations that weren't stopped.
+    nodeDataChannel.cleanup();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -182,6 +182,7 @@ describe('DataChannel streams', () => {
 
         expect(await clientResponsePromise).toBe('test message');
 
+        clientChannel.close();
         clientPeer.close();
         echoPeer.close();
     });


### PR DESCRIPTION
This PR refactors cleanup on close to prevent JS callbacks from running between the call to `close()` and the `onClose` callback. The approach is simplified: `close()` now cleans up immediately and the `onClose` or `onStateChange(State::Closed)` callbacks are now allowed to run afterwards.

The difference for the user is that the underlying libdatachannel object is not destroyed on remote close, it is destroyed on `close()`, on global `cleanup()`, or on garbage collection.

It should fix https://github.com/murat-dogan/node-datachannel/issues/103