### PR TITLE
Update libdatachannel to v0.17.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ include(FetchContent)
 FetchContent_Declare(
     libdatachannel
     GIT_REPOSITORY https://github.com/paullouisageneau/libdatachannel.git
-    GIT_TAG "v0.17.3"
+    GIT_TAG "v0.17.6"
 )
 
 option(NO_MEDIA "Disable media transport support in libdatachannel" OFF)


### PR DESCRIPTION
This PR updates libdatachannel to v0.17.6 to include the fix for https://github.com/paullouisageneau/libdatachannel/issues/645