### PR TITLE
Update libdatachannel to v0.17.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ include(FetchContent)
 FetchContent_Declare(
     libdatachannel
     GIT_REPOSITORY https://github.com/paullouisageneau/libdatachannel.git
-    GIT_TAG "v0.17.6"
+    GIT_TAG "v0.17.7"
 )
 
 option(NO_MEDIA "Disable media transport support in libdatachannel" OFF)


### PR DESCRIPTION
The fix for https://github.com/paullouisageneau/libdatachannel/issues/645 in v0.17.6 introduced a regression (remote peer disconnection delays), which is fixed in v0.17.7