### PR TITLE
Make description type case consistent

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -59,12 +59,13 @@ export interface RtcConfig {
     iceTransportPolicy?: TransportPolicy;
 }
 
+// Lowercase to match the description type string from libdatachannel
 export const enum DescriptionType {
-    Unspec = 'Unspec',
-    Offer = 'Offer',
-    Answer = 'Answer',
-    Pranswer = 'Pranswer',
-    Rollback = 'Rollback',
+    Unspec = 'unspec',
+    Offer = 'offer',
+    Answer = 'answer',
+    Pranswer = 'pranswer',
+    Rollback = 'rollback',
 }
 
 export const enum ReliabilityType {

--- a/src/peer-connection-wrapper.cpp
+++ b/src/peer-connection-wrapper.cpp
@@ -4,6 +4,7 @@
 #include "media-video-wrapper.h"
 #include "media-audio-wrapper.h"
 
+#include <cctype>
 #include <sstream>
 
 Napi::FunctionReference PeerConnectionWrapper::constructor;
@@ -281,13 +282,17 @@ void PeerConnectionWrapper::setLocalDescription(const Napi::CallbackInfo &info)
         }
         std::string typeStr = info[0].As<Napi::String>().ToString();
 
-        if (typeStr == "Answer")
+        // Accept uppercase first letter for backward compatibility
+        if(typeStr.size() > 0)
+            typeStr[0] = std::tolower(typeStr[0]);
+
+        if (typeStr == "answer")
             type = rtc::Description::Type::Answer;
-        if (typeStr == "Offer")
+        else if (typeStr == "offer")
             type = rtc::Description::Type::Offer;
-        if (typeStr == "Pranswer")
+        else if (typeStr == "pranswer")
             type = rtc::Description::Type::Pranswer;
-        if (typeStr == "Rollback")
+        else if (typeStr == "rollback")
             type = rtc::Description::Type::Rollback;
     }
 


### PR DESCRIPTION
There was an inconsistency as `DescriptionType` was defined with uppercase first letter while the libdatachannel outputs the description type with lowercase first letter. As a result, the `type` received by `onLocalDescription` or expected by `setRemoteDescription`, while defined as `DescriptionType`, did not match enum values. Only `setLocalDescription` expected actual enum values.

This PR changes enum values to lowercase so everything is consistent, and allows for retro-compatibility by accepting both lowercase and uppercase in `setLocalDescription`.