### PR TITLE
Introduce destroy function

### DIFF
--- a/API.md
+++ b/API.md
@@ -49,6 +49,10 @@ TURN Server Example (TLS)    : turns:USERNAME:PASSWORD@TURN_IP_OR_ADDRESS:PORT
 
 Close Peer Connection
 
+**destroy: () => void**
+
+Close Peer Connection & Clear all callbacks
+
 **setRemoteDescription: (sdp: string, type: DescriptionType) => void**
 
 Set Remote Description

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 cmake_policy(SET CMP0091 NEW)
-project(node_datachannel VERSION 0.3.6)
+project(node_datachannel VERSION 0.4.0)
 
 # Workaround for https://github.com/murat-dogan/node-datachannel/issues/65
 if( NODE_RUNTIMEVERSION VERSION_GREATER_EQUAL "17.0.0")
@@ -38,7 +38,7 @@ include(FetchContent)
 FetchContent_Declare(
     libdatachannel
     GIT_REPOSITORY https://github.com/paullouisageneau/libdatachannel.git
-    GIT_TAG "v0.17.9"
+    GIT_TAG "v0.17.10"
 )
 
 option(NO_MEDIA "Disable media transport support in libdatachannel" OFF)
@@ -73,9 +73,12 @@ target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_BINARY_DIR}/_deps/libdatachannel-src/include
 )
 
-# For compatibility with Node.js 12
-# This should be removed along with the napi-thread-safe-callback-cancellable dependency when dropping support at end-of-life
-target_compile_definitions(${PROJECT_NAME} PRIVATE -DLEGACY_NAPI_THREAD_SAFE_CALLBACK)
+if( NODE_RUNTIMEVERSION VERSION_LESS "13.0.0")
+    # For compatibility with Node.js 12
+    # This should be removed along with the napi-thread-safe-callback-cancellable dependency when dropping support at end-of-life
+    target_compile_definitions(${PROJECT_NAME} PRIVATE -DLEGACY_NAPI_THREAD_SAFE_CALLBACK)    
+endif()
+
 target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_SOURCE_DIR}/node_modules/napi-thread-safe-callback-cancellable
 )

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -204,6 +204,7 @@ export class DataChannel {
 export class PeerConnection {
     constructor(peerName: string, config: RtcConfig);
     close(): void;
+    destroy(): void;
     setLocalDescription(type?: DescriptionType): void;
     setRemoteDescription(sdp: string, type: DescriptionType): void;
     localDescription(): { type: string; sdp: string } | null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-datachannel",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-datachannel",
-  "version": "0.3.6",
+  "version": "0.4.0",
   "description": "libdatachannel node bindings",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "install": "prebuild-install || (npm install --ignore-scripts && npm run _prebuild)",
     "install-nice": "npm run clean && cmake-js build --CDUSE_NICE=1",
     "build": "cmake-js build",
+    "build:debug": "cmake-js build -D",
     "_prebuild": "prebuild --backend cmake-js",
     "clean": "cmake-js clean",
     "lint": "eslint lib/**/* test/**/*",

--- a/src/peer-connection-wrapper.cpp
+++ b/src/peer-connection-wrapper.cpp
@@ -21,7 +21,7 @@ void PeerConnectionWrapper::ResetCallbacksAll()
 {
     auto copy(instances);
     for (auto inst : copy)
-        inst->resetCallbacks();
+        inst->doResetCallbacks();
 }
 
 Napi::Object PeerConnectionWrapper::Init(Napi::Env env, Napi::Object exports)
@@ -261,10 +261,10 @@ void PeerConnectionWrapper::close(const Napi::CallbackInfo &info)
 void PeerConnectionWrapper::doDestroy()
 {
     doClose();
-    resetCallbacks();
+    doResetCallbacks();
 }
 
-void PeerConnectionWrapper::resetCallbacks()
+void PeerConnectionWrapper::doResetCallbacks()
 {  
     mOnLocalDescriptionCallback.reset();
     mOnLocalCandidateCallback.reset();

--- a/src/peer-connection-wrapper.cpp
+++ b/src/peer-connection-wrapper.cpp
@@ -17,6 +17,13 @@ void PeerConnectionWrapper::CloseAll()
         inst->doClose();
 }
 
+void PeerConnectionWrapper::ResetCallbacksAll()
+{
+    auto copy(instances);
+    for (auto inst : copy)
+        inst->resetCallbacks();
+}
+
 Napi::Object PeerConnectionWrapper::Init(Napi::Env env, Napi::Object exports)
 {
     Napi::HandleScope scope(env);
@@ -26,6 +33,7 @@ Napi::Object PeerConnectionWrapper::Init(Napi::Env env, Napi::Object exports)
         "PeerConnection",
         {
             InstanceMethod("close", &PeerConnectionWrapper::close),
+            InstanceMethod("destroy", &PeerConnectionWrapper::destroy),
             InstanceMethod("setLocalDescription", &PeerConnectionWrapper::setLocalDescription),
             InstanceMethod("setRemoteDescription", &PeerConnectionWrapper::setRemoteDescription),
             InstanceMethod("localDescription", &PeerConnectionWrapper::localDescription),
@@ -225,7 +233,7 @@ PeerConnectionWrapper::PeerConnectionWrapper(const Napi::CallbackInfo &info) : N
 
 PeerConnectionWrapper::~PeerConnectionWrapper()
 {
-    doClose();
+    doDestroy();
 }
 
 void PeerConnectionWrapper::doClose()
@@ -243,7 +251,21 @@ void PeerConnectionWrapper::doClose()
             return;
         }
     }
+}
 
+void PeerConnectionWrapper::close(const Napi::CallbackInfo &info)
+{
+    doClose();
+}
+
+void PeerConnectionWrapper::doDestroy()
+{
+    doClose();
+    resetCallbacks();
+}
+
+void PeerConnectionWrapper::resetCallbacks()
+{  
     mOnLocalDescriptionCallback.reset();
     mOnLocalCandidateCallback.reset();
     mOnStateChangeCallback.reset();
@@ -254,9 +276,9 @@ void PeerConnectionWrapper::doClose()
     instances.erase(this);
 }
 
-void PeerConnectionWrapper::close(const Napi::CallbackInfo &info)
+void PeerConnectionWrapper::destroy(const Napi::CallbackInfo &info)
 {
-    doClose();
+    doDestroy();
 }
 
 void PeerConnectionWrapper::setLocalDescription(const Napi::CallbackInfo &info)
@@ -639,9 +661,8 @@ void PeerConnectionWrapper::onStateChange(const Napi::CallbackInfo &info)
 
     mRtcPeerConnPtr->onStateChange([&](rtc::PeerConnection::State state) {
         if (mOnStateChangeCallback)
-            mOnStateChangeCallback->call([this, state](Napi::Env env, std::vector<napi_value> &args) {
-                // Check the peer connection is not closed but still allow a call for State::Closed
-                if(state != rtc::PeerConnection::State::Closed && instances.find(this) == instances.end())
+            mOnStateChangeCallback->call([this, state](Napi::Env env, std::vector<napi_value> &args) {                
+                if(instances.find(this) == instances.end())
                     throw ThreadSafeCallback::CancelException();
 
                 // This will run in main thread and needs to construct the

--- a/src/peer-connection-wrapper.h
+++ b/src/peer-connection-wrapper.h
@@ -19,6 +19,8 @@ public:
   PeerConnectionWrapper(const Napi::CallbackInfo &info);
   ~PeerConnectionWrapper();
 
+  void destroy(const Napi::CallbackInfo &info);
+
   // Functions
   void close(const Napi::CallbackInfo &info);
   void setLocalDescription(const Napi::CallbackInfo &info);
@@ -47,14 +49,19 @@ public:
   Napi::Value rtt(const Napi::CallbackInfo &info);
   Napi::Value getSelectedCandidatePair(const Napi::CallbackInfo &info);
 
-  // Close all existing DataChannels
+  // Close all existing Peer Connections
   static void CloseAll();
+
+  // Reset all Callbacks for existing Peer Connections
+  static void ResetCallbacksAll();
 
 private:
   static Napi::FunctionReference constructor;
   static std::unordered_set<PeerConnectionWrapper *> instances;
 
   void doClose();
+  void doDestroy();
+  void resetCallbacks();
 
   std::string mPeerName;
   std::unique_ptr<rtc::PeerConnection> mRtcPeerConnPtr = nullptr;

--- a/src/peer-connection-wrapper.h
+++ b/src/peer-connection-wrapper.h
@@ -61,7 +61,7 @@ private:
 
   void doClose();
   void doDestroy();
-  void resetCallbacks();
+  void doResetCallbacks();
 
   std::string mPeerName;
   std::unique_ptr<rtc::PeerConnection> mRtcPeerConnPtr = nullptr;

--- a/src/rtc-wrapper.cpp
+++ b/src/rtc-wrapper.cpp
@@ -82,7 +82,10 @@ void RtcWrapper::cleanup(const Napi::CallbackInfo &info)
         const auto timeout = std::chrono::seconds(10);
         if(rtc::Cleanup().wait_for(std::chrono::seconds(timeout)) == std::future_status::timeout)
             throw std::runtime_error("cleanup timeout (possible deadlock)");
-    }
+        
+        // Clear Callbacks    
+        PeerConnectionWrapper::ResetCallbacksAll();
+    }        
     catch (std::exception &ex)
     {
         Napi::Error::New(env, std::string("libdatachannel error# ") + ex.what()).ThrowAsJavaScriptException();


### PR DESCRIPTION
Closing the peer connection & clearing the js callbacks at the same time makes it so complicated to manage.

I am introducing a new function named `destroy`. This function will clear js callbacks explicitly. `cleanup` function also now calls `resetcallbacks, explicitly to make a clean shutdown.

Also, node version>=13 will not use old napi thread-safe callback functions.

Actually, this is not a breaking change. (kind of :) ) But I will bump the version to 0.4.0