### PR TITLE
Bump version and add logger callback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ include(FetchContent)
 FetchContent_Declare(
     libdatachannel
     GIT_REPOSITORY https://github.com/paullouisageneau/libdatachannel.git
-    GIT_TAG "v0.17.10"
+    GIT_TAG "v0.17.12"
 )
 
 option(NO_MEDIA "Disable media transport support in libdatachannel" OFF)

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -17,7 +17,7 @@ export interface SctpSettings {
 
 // Functions
 export function preload(): void;
-export function initLogger(level: LogLevel): void;
+export function initLogger(level: LogLevel, callback?: (level: number, message: string) => void): void;
 export function cleanup(): void;
 export function setSctpSettings(settings: SctpSettings): void;
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -17,7 +17,7 @@ export interface SctpSettings {
 
 // Functions
 export function preload(): void;
-export function initLogger(level: LogLevel, callback?: (level: number, message: string) => void): void;
+export function initLogger(level: LogLevel, callback?: (level: LogLevel, message: string) => void): void;
 export function cleanup(): void;
 export function setSctpSettings(settings: SctpSettings): void;
 

--- a/src/rtc-wrapper.cpp
+++ b/src/rtc-wrapper.cpp
@@ -81,7 +81,7 @@ void RtcWrapper::initLogger(const Napi::CallbackInfo &info)
 
                         std::string logLevel;
                         if (level == rtc::LogLevel::Verbose)
-                            logLevel = "Verbos";
+                            logLevel = "Verbose";
                         if (level == rtc::LogLevel::Debug)
                             logLevel = "Debug";
                         if (level == rtc::LogLevel::Info)

--- a/src/rtc-wrapper.cpp
+++ b/src/rtc-wrapper.cpp
@@ -67,6 +67,11 @@ void RtcWrapper::initLogger(const Napi::CallbackInfo &info)
         }
         else
         {
+            if (!info[1].IsFunction())
+            {
+                Napi::TypeError::New(env, "Function expected").ThrowAsJavaScriptException();
+                return;
+            }
             logCallback = std::make_unique<ThreadSafeCallback>(info[1].As<Napi::Function>());
             rtc::InitLogger(logLevel, [&](rtc::LogLevel level, std::string message) {
                 if (logCallback)

--- a/src/rtc-wrapper.cpp
+++ b/src/rtc-wrapper.cpp
@@ -78,7 +78,21 @@ void RtcWrapper::initLogger(const Napi::CallbackInfo &info)
                     logCallback->call([level, message = std::move(message)](Napi::Env env, std::vector<napi_value> &args) {
                         // This will run in main thread and needs to construct the
                         // arguments for the call
-                        args = {Napi::Number::New(env, static_cast<int>(level)), Napi::String::New(env, message)};
+
+                        std::string logLevel;
+                        if (level == rtc::LogLevel::Verbose)
+                            logLevel = "Verbos";
+                        if (level == rtc::LogLevel::Debug)
+                            logLevel = "Debug";
+                        if (level == rtc::LogLevel::Info)
+                            logLevel = "Info";
+                        if (level == rtc::LogLevel::Warning)
+                            logLevel = "Warning";
+                        if (level == rtc::LogLevel::Error)
+                            logLevel = "Error";
+                        if (level == rtc::LogLevel::Fatal)
+                            logLevel = "Fatal";
+                        args = {Napi::String::New(env, logLevel), Napi::String::New(env, message)};
                     });
             });
         }

--- a/src/rtc-wrapper.h
+++ b/src/rtc-wrapper.h
@@ -8,6 +8,8 @@
 
 #include "rtc/rtc.hpp"
 
+#include "thread-safe-callback.h"
+
 class RtcWrapper
 {
 public:
@@ -16,6 +18,8 @@ public:
     static void initLogger(const Napi::CallbackInfo &info);
     static void cleanup(const Napi::CallbackInfo &info);
     static void setSctpSettings(const Napi::CallbackInfo &info);
+private:
+    static inline std::unique_ptr<ThreadSafeCallback> logCallback = nullptr;
 };
 
 #endif // RTC_WRAPPER_H


### PR DESCRIPTION
- Bump libdatachannel version to v0.17.12
- Add optional log callback to `initLogger`

Some background:

I'm using the lib in electron and debug with vscode debugger.

The vscode debugger cannot capture the log pipe to stdout by default, and I want to add option to my program to pipe the libdatachannel's log to a specific file.

Since I encountered the strange crash, I think I need to collect the log to a logfile for this lib from user to help diagnose.