### PR TITLE
Build for Node v19

### DIFF
--- a/.github/workflows/build-linux-arm64-test.yml
+++ b/.github/workflows/build-linux-arm64-test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 13.x, 14.x, 15.x, 16.x, 17.x]
+        node-version: [12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
     steps:
       - uses: actions/checkout@v2
       - name: Prepare Cross Compile

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x]
+        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x]
+        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
     steps:
       - uses: actions/checkout@v2
       - name: Prepare Cross Compile
@@ -68,7 +68,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x]
+        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
     steps:
       - uses: actions/checkout@v2
       - name: Prepare Cross Compile

--- a/.github/workflows/build-mac-m1.yml
+++ b/.github/workflows/build-mac-m1.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x]
+        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-mac-x64.yml
+++ b/.github/workflows/build-mac-x64.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x]
+        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x]
+        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        node_version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x]
+        node_version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
         node_arch:
           - x86
     steps:
@@ -52,7 +52,7 @@ jobs:
           arch: x86
       - name: Install OpenSSL
         run: choco install openssl --x86=true
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node_version }}
         uses: aminya/setup-node@x86
         with:
           node-version: ${{ matrix.node_version }}


### PR DESCRIPTION
This adds Node v19 to all CI builds, so that a) it's tested automatically, and b) v19 prebuilds are available. Node v19 is the active node release now, from October 2022 until April 2023, so I expect lots of people are using it already.

I've also fixed a tiny typo in the build-win config, which means that the node version wasn't appearing the name of the build step as intended.

In future, it might be worth adding a `*` value and using `check-latest: true` to ensure that builds _always_ run against the latest version? We'd still need to manually add versions to the list eventually, but that way at least we'd start doing some initial testing & prebuilds automatically straight away when a new version comes out.

Alternatively I don't know if it's possible/difficult to start building for [NAPI](https://nodejs.org/api/n-api.html#node-api) instead of building separately for specific Node versions? That way the builds would work for all compatible NAPI versions forever, without needing an update every 6 months for new Node releases.