### PR TITLE
Fix prebuild failing when NODE_ENV is set to production

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "_from": "node-datachannel@latest",
   "scripts": {
-    "install": "prebuild-install || (npm install --ignore-scripts && npm run _prebuild)",
+    "install": "prebuild-install || (npm install --ignore-scripts --production=false && npm run _prebuild)",
     "install-nice": "npm run clean && cmake-js build --CDUSE_NICE=1",
     "build": "cmake-js build",
     "build:debug": "cmake-js build -D",


### PR DESCRIPTION
A build server was throwing this error:

```bash 
npm WARN config production Use `--omit=dev` instead.
npm WARN config cache-min This option has been deprecated in favor of `--prefer-offline`.
npm WARN using --force Recommended protections disabled.
npm ERR! code 127
npm ERR! path /worker/app-94f05526-221a-4bb5-939e-940577314505/node_modules/node-datachannel
npm ERR! command failed
npm ERR! command sh -c prebuild-install || (npm install --ignore-scripts && npm run _prebuild)
npm ERR! added 1 package, removed 1 package, and audited 59 packages in 12s
npm ERR! 
npm ERR! 7 packages are looking for funding
npm ERR!   run `npm fund` for details
npm ERR! 
npm ERR! found 0 vulnerabilities
npm ERR! 
npm ERR! > node-datachannel@0.4.0 _prebuild
npm ERR! > prebuild --backend cmake-js
npm ERR! prebuild-install WARN install No prebuilt binaries found (target=18.2.2 runtime=electron arch=x64 libc= platform=darwin)
npm ERR! npm WARN using --force Recommended protections disabled.
npm ERR! npm WARN using --force Recommended protections disabled.
npm ERR! sh: 1: prebuild: not found
```

Looking at package.json, I assume that the `npm install` is to install the build tools. Since afaik the server is using NODE_ENV to tell npm to run in production mode, since the command does not override the mode, it will install it in production mode, not installing the build tools.

I have not tested the fix but I assume this will do.