### PR TITLE
Add support for the forceMediaTransport option

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -54,6 +54,7 @@ export interface RtcConfig {
     enableIceTcp?: boolean;
     enableIceUdpMux?: boolean;
     disableAutoNegotiation?: boolean;
+    forceMediaTransport?: boolean;
     portRangeBegin?: number;
     portRangeEnd?: number;
     maxMessageSize?: number;

--- a/src/peer-connection-wrapper.cpp
+++ b/src/peer-connection-wrapper.cpp
@@ -193,6 +193,10 @@ PeerConnectionWrapper::PeerConnectionWrapper(const Napi::CallbackInfo &info) : N
     if (config.Get("disableAutoNegotiation").IsBoolean())
         rtcConfig.disableAutoNegotiation = config.Get("disableAutoNegotiation").As<Napi::Boolean>();
 
+    // forceMediaTransport option
+    if (config.Get("forceMediaTransport").IsBoolean())
+        rtcConfig.forceMediaTransport = config.Get("forceMediaTransport").As<Napi::Boolean>();
+
     // Max Message Size
     if (config.Get("maxMessageSize").IsNumber())
         rtcConfig.maxMessageSize = config.Get("maxMessageSize").As<Napi::Number>().Int32Value();


### PR DESCRIPTION
This is a relatively recent libdatachannel addition that wasn't included here, that I need to be able to renegotiate and add media channels at runtime in the latest releases.