### PR TITLE
Fix the README build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Easy to use WebRTC data channels and media transport
 
-![Build CI](https://github.com/murat-dogan/node-datachannel/workflows/Build%20CI/badge.svg)
+![Linux CI Build](https://github.com/murat-dogan/node-datachannel/workflows/Build%20-%20Linux/badge.svg) ![Windows CI Build](https://github.com/murat-dogan/node-datachannel/workflows/Build%20-%20Win/badge.svg) ![Mac x64 CI Build](https://github.com/murat-dogan/node-datachannel/workflows/Build%20-%20Mac%20x64/badge.svg) ![Mac M1 CI Build](https://github.com/murat-dogan/node-datachannel/workflows/Build%20-%20Mac%20M1/badge.svg)
 
 - Easy to use
 - Lightweight


### PR DESCRIPTION
Not really important at all, but I noticed that it broke at some point, and it's nice to fix it up :smile:. Expanding to cover the current set of builds also neatly shows off the current platform prebuild support!