### PR TITLE
Build for Node 20

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x, 20.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x, 20.x]
     steps:
       - uses: actions/checkout@v2
       - name: Prepare Cross Compile
@@ -48,7 +48,7 @@ jobs:
           sudo apt update
           sudo apt install -y g++-arm-linux-gnueabihf gcc-arm-linux-gnueabihf
           mkdir sysroot && cd sysroot
-          wget https://commondatastorage.googleapis.com/chrome-linux-sysroot/toolchain/ef5c4f84bcafb7a3796d36bb1db7826317dde51c/debian_sid_arm_sysroot.tar.xz        
+          wget https://commondatastorage.googleapis.com/chrome-linux-sysroot/toolchain/ef5c4f84bcafb7a3796d36bb1db7826317dde51c/debian_sid_arm_sysroot.tar.xz
           tar xf debian_sid_arm_sysroot.tar.xz
           echo "ARM_SYSROOT=$(pwd)" >> $GITHUB_ENV
           ls -l
@@ -68,7 +68,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x, 20.x]
     steps:
       - uses: actions/checkout@v2
       - name: Prepare Cross Compile
@@ -76,7 +76,7 @@ jobs:
           sudo apt update
           sudo apt install -y g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
           mkdir sysroot && cd sysroot
-          wget https://commondatastorage.googleapis.com/chrome-linux-sysroot/toolchain/953c2471bc7e71a788309f6c2d2003e8b703305d/debian_sid_arm64_sysroot.tar.xz        
+          wget https://commondatastorage.googleapis.com/chrome-linux-sysroot/toolchain/953c2471bc7e71a788309f6c2d2003e8b703305d/debian_sid_arm64_sysroot.tar.xz
           tar xf debian_sid_arm64_sysroot.tar.xz
           echo "ARM64_SYSROOT=$(pwd)" >> $GITHUB_ENV
           ls -l

--- a/.github/workflows/build-mac-m1.yml
+++ b/.github/workflows/build-mac-m1.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-mac-x64.yml
+++ b/.github/workflows/build-mac-x64.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x, 20.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x, 20.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        node_version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x]
+        node_version: [10.x, 11.x, 12.x, 13.x, 14.x, 15.x, 16.x, 17.x, 18.x, 19.x, 20.x]
         node_arch:
           - x86
     steps:


### PR DESCRIPTION
The recent [release 0.4.2](https://github.com/murat-dogan/node-datachannel/releases/tag/v0.4.2) doesn't yet contain assets for [Node 20 (Module version 115)](https://nodejs.org/en/download/releases). Looking at #149 my understanding is, that it just needs adding `, 20.x` in a couple places to build it in the future also for Node 20.