### PR TITLE
fix: reset mOnSignalingStateChangeCallback in doResetCallbacks

### DIFF
--- a/src/peer-connection-wrapper.cpp
+++ b/src/peer-connection-wrapper.cpp
@@ -277,6 +277,7 @@ void PeerConnectionWrapper::doResetCallbacks()
     mOnLocalDescriptionCallback.reset();
     mOnLocalCandidateCallback.reset();
     mOnStateChangeCallback.reset();
+    mOnSignalingStateChangeCallback.reset();
     mOnGatheringStateChangeCallback.reset();
     mOnDataChannelCallback.reset();
     mOnTrackCallback.reset();


### PR DESCRIPTION
Looks like reseting the callback for `onSignalingStateChange` was missed - this can prevent the node process from exiting when shutting things down.