### PR TITLE
Update libdatachannel to v0.18.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ include(FetchContent)
 FetchContent_Declare(
     libdatachannel
     GIT_REPOSITORY https://github.com/paullouisageneau/libdatachannel.git
-    GIT_TAG "v0.18.5"
+    GIT_TAG "v0.18.6"
 )
 
 option(NO_MEDIA "Disable media transport support in libdatachannel" OFF)


### PR DESCRIPTION
This PR updates libdatachannel to v0.18.6. In particular, it fixes the "Got unexpected message" issue when the remote peer closes a datachannel when the local peer is still sending seen in https://github.com/murat-dogan/node-datachannel/issues/188.
