### PR TITLE
FIX types and add CI check for types

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,3 +17,4 @@ jobs:
           node-version: '16.x'
       - run: npm ci
       - run: npm run lint
+      - run: npm run test-types

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,7 @@
     "packages": {
         "": {
             "name": "node-datachannel",
-            "version": "0.5.0-dev",
-            "bundleDependencies": [
-                "prebuild-install"
-            ],
+            "version": "0.5.1",
             "hasInstallScript": true,
             "license": "MPL 2.0",
             "dependencies": {
@@ -28,7 +25,7 @@
                 "node-addon-api": "^7.0.0",
                 "prebuild": "^12.0.0",
                 "prettier": "^2.8.8",
-                "typescript": "^4.6.3"
+                "typescript": "5.3.2"
             },
             "engines": {
                 "node": ">=16.0.0"
@@ -2159,8 +2156,7 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "inBundle": true
+            ]
         },
         "node_modules/bcrypt-pbkdf": {
             "version": "1.0.2",
@@ -2324,7 +2320,6 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "inBundle": true,
             "dependencies": {
                 "base64-js": "^1.3.1",
                 "ieee754": "^1.1.13"
@@ -2608,8 +2603,7 @@
         "node_modules/chownr": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-            "inBundle": true
+            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
         "node_modules/ci-info": {
             "version": "3.8.0",
@@ -2908,7 +2902,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
             "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-            "inBundle": true,
             "dependencies": {
                 "mimic-response": "^3.1.0"
             },
@@ -2937,7 +2930,6 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
             "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "inBundle": true,
             "engines": {
                 "node": ">=4.0.0"
             }
@@ -2976,7 +2968,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
             "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
-            "inBundle": true,
             "engines": {
                 "node": ">=8"
             }
@@ -3107,7 +3098,6 @@
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
             "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "inBundle": true,
             "dependencies": {
                 "once": "^1.4.0"
             }
@@ -3483,7 +3473,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
             "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "inBundle": true,
             "engines": {
                 "node": ">=6"
             }
@@ -3736,8 +3725,7 @@
         "node_modules/fs-constants": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-            "inBundle": true
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
         },
         "node_modules/fs-extra": {
             "version": "5.0.0",
@@ -3924,8 +3912,7 @@
         "node_modules/github-from-package": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-            "inBundle": true
+            "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
         },
         "node_modules/glob": {
             "version": "7.2.3",
@@ -4155,8 +4142,7 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "inBundle": true
+            ]
         },
         "node_modules/ignore": {
             "version": "5.2.4",
@@ -4233,14 +4219,12 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "inBundle": true
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "node_modules/ini": {
             "version": "1.3.8",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-            "inBundle": true
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
         },
         "node_modules/invert-kv": {
             "version": "1.0.0",
@@ -5515,7 +5499,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
             "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-            "inBundle": true,
             "engines": {
                 "node": ">=10"
             },
@@ -5539,7 +5522,6 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-            "inBundle": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -5745,8 +5727,7 @@
         "node_modules/mkdirp-classic": {
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-            "inBundle": true
+            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
         },
         "node_modules/ms": {
             "version": "2.1.2",
@@ -5757,8 +5738,7 @@
         "node_modules/napi-build-utils": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-            "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-            "inBundle": true
+            "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -5791,7 +5771,6 @@
             "version": "3.47.0",
             "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.47.0.tgz",
             "integrity": "sha512-2s6B2CWZM//kPgwnuI0KrYwNjfdByE25zvAaEpq9IH4zcNsarH8Ihu/UuX6XMPEogDAxkuUFeZn60pXNHAqn3A==",
-            "inBundle": true,
             "dependencies": {
                 "semver": "^7.3.5"
             },
@@ -6294,7 +6273,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "inBundle": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -6665,7 +6643,6 @@
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
             "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
-            "inBundle": true,
             "dependencies": {
                 "detect-libc": "^2.0.0",
                 "expand-template": "^2.0.3",
@@ -7247,7 +7224,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
             "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "inBundle": true,
             "dependencies": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -7317,7 +7293,6 @@
             "version": "1.2.8",
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "inBundle": true,
             "dependencies": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -7332,7 +7307,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-            "inBundle": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7573,8 +7547,7 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "inBundle": true
+            ]
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
@@ -7586,7 +7559,6 @@
             "version": "7.5.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
             "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-            "inBundle": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -7601,7 +7573,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "inBundle": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -7612,8 +7583,7 @@
         "node_modules/semver/node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "inBundle": true
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/set-blocking": {
             "version": "2.0.0",
@@ -7671,8 +7641,7 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ],
-            "inBundle": true
+            ]
         },
         "node_modules/simple-get": {
             "version": "4.0.1",
@@ -7692,7 +7661,6 @@
                     "url": "https://feross.org/support"
                 }
             ],
-            "inBundle": true,
             "dependencies": {
                 "decompress-response": "^6.0.0",
                 "once": "^1.3.1",
@@ -8054,7 +8022,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
             "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "inBundle": true,
             "dependencies": {
                 "chownr": "^1.1.1",
                 "mkdirp-classic": "^0.5.2",
@@ -8066,7 +8033,6 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
             "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-            "inBundle": true,
             "dependencies": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -8077,7 +8043,6 @@
             "version": "3.6.2",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
             "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-            "inBundle": true,
             "dependencies": {
                 "inherits": "^2.0.3",
                 "string_decoder": "^1.1.1",
@@ -8091,7 +8056,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-            "inBundle": true,
             "dependencies": {
                 "safe-buffer": "~5.2.0"
             }
@@ -8100,7 +8064,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
             "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "inBundle": true,
             "dependencies": {
                 "bl": "^4.0.3",
                 "end-of-stream": "^1.4.1",
@@ -8242,7 +8205,6 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-            "inBundle": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
@@ -8296,16 +8258,16 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+            "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
             "dev": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
             }
         },
         "node_modules/unique-filename": {
@@ -8454,8 +8416,7 @@
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-            "inBundle": true
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
         },
         "node_modules/util-extend": {
             "version": "1.0.3",
@@ -8627,8 +8588,7 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "inBundle": true
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
         },
         "node_modules/write-file-atomic": {
             "version": "4.0.2",
@@ -10014,8 +9974,7 @@
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "after": {
             "version": "0.8.2",
@@ -10895,8 +10854,7 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
             "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "deep-extend": {
             "version": "0.6.0",
@@ -11175,8 +11133,7 @@
             "version": "8.10.0",
             "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
             "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "eslint-plugin-prettier": {
             "version": "4.2.1",
@@ -12366,8 +12323,7 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
             "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-            "dev": true,
-            "requires": {}
+            "dev": true
         },
         "jest-regex-util": {
             "version": "29.6.3",
@@ -14989,9 +14945,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+            "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
             "dev": true
         },
         "unique-filename": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
         "clean": "cmake-js clean",
         "lint": "eslint lib/**/* test/**/*",
         "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-        "wpt-test": "node test/wpt.js"
+        "wpt-test": "node test/wpt.js",
+        "test-types": "tsc"
     },
     "binary": {
         "napi_versions": [
@@ -72,7 +73,7 @@
         "node-addon-api": "^7.0.0",
         "prebuild": "^12.0.0",
         "prettier": "^2.8.8",
-        "typescript": "^4.6.3"
+        "typescript": "^5.3.2"
     },
     "dependencies": {
         "node-domexception": "^2.0.1",

--- a/polyfill/RTCPeerConnection.d.ts
+++ b/polyfill/RTCPeerConnection.d.ts
@@ -36,7 +36,6 @@ export default class _RTCPeerConnection extends EventTarget implements RTCPeerCo
     close(): void;
     createAnswer(options?: RTCAnswerOptions): Promise<RTCSessionDescriptionInit>;
     createAnswer(successCallback: RTCSessionDescriptionCallback, failureCallback: RTCPeerConnectionErrorCallback): Promise<void>;
-
     createDataChannel(label: string, dataChannelDict?: RTCDataChannelInit): RTCDataChannel;
     createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescriptionInit>;
     createOffer(successCallback: RTCSessionDescriptionCallback, failureCallback: RTCPeerConnectionErrorCallback, options?: RTCOfferOptions): Promise<void>;

--- a/polyfill/RTCPeerConnection.d.ts
+++ b/polyfill/RTCPeerConnection.d.ts
@@ -35,8 +35,11 @@ export default class _RTCPeerConnection extends EventTarget implements RTCPeerCo
     addTransceiver(trackOrKind: MediaStreamTrack | string, init?: RTCRtpTransceiverInit): RTCRtpTransceiver;
     close(): void;
     createAnswer(options?: RTCAnswerOptions): Promise<RTCSessionDescriptionInit>;
+    createAnswer(successCallback: RTCSessionDescriptionCallback, failureCallback: RTCPeerConnectionErrorCallback): Promise<void>;
+
     createDataChannel(label: string, dataChannelDict?: RTCDataChannelInit): RTCDataChannel;
     createOffer(options?: RTCOfferOptions): Promise<RTCSessionDescriptionInit>;
+    createOffer(successCallback: RTCSessionDescriptionCallback, failureCallback: RTCPeerConnectionErrorCallback, options?: RTCOfferOptions): Promise<void>;
     getConfiguration(): RTCConfiguration;
     getReceivers(): RTCRtpReceiver[];
     getSenders(): RTCRtpSender[];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
       "noEmit": true
     },
     "exclude": [
-      "node_modules",
-      "dist"
+      "node_modules"
     ]
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+      "target": "es5",
+      "module": "commonjs",
+      "declaration": true,
+      "strict": true,
+      "esModuleInterop": true,
+      "noEmit": true
+    },
+    "exclude": [
+      "node_modules",
+      "dist"
+    ]
+  }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
       "noEmit": true
     },
     "exclude": [
-      "node_modules"
+      "node_modules",
+      "build"
     ]
   }


### PR DESCRIPTION
The typescript types are broken and throw the following error:

![error-types](https://github.com/murat-dogan/node-datachannel/assets/8926560/6582d797-ac6a-4b14-921f-d44282effc56)


This PR contains the following:
- Fixes for the typings.
- Update typescript to `5.3.2`.
- Add a CI check to ensure the types will not break in the future.