### PR TITLE
fix: add constructor args to RTCSessionDescription polyfill

### DIFF
--- a/polyfill/RTCSessionDescription.d.ts
+++ b/polyfill/RTCSessionDescription.d.ts
@@ -4,4 +4,5 @@ export default class _RTCSessionDescription implements RTCSessionDescription {
     readonly sdp: string;
     readonly type: RTCSdpType;
     toJSON(): any;
+    constructor(descriptionInitDict?: RTCSessionDescriptionInit);
 }


### PR DESCRIPTION
Adds the optional init dict so it's usable from typescript.