### PR TITLE
fix: add generate certificate method to peer connection polyfill

### DIFF
--- a/polyfill/RTCPeerConnection.d.ts
+++ b/polyfill/RTCPeerConnection.d.ts
@@ -56,4 +56,7 @@ export default class _RTCPeerConnection extends EventTarget implements RTCPeerCo
     setConfiguration(configuration: RTCConfiguration): void;
     setLocalDescription(description: RTCSessionDescriptionInit): Promise<void>;
     setRemoteDescription(description: RTCSessionDescriptionInit): Promise<void>;
+
+    // static methods
+    static generateCertificate(keygenAlgorithm: AlgorithmIdentifier): Promise<RTCCertificate>;
 }

--- a/polyfill/RTCPeerConnection.js
+++ b/polyfill/RTCPeerConnection.js
@@ -7,6 +7,10 @@ import RTCSctpTransport from './RTCSctpTransport.js';
 import DOMException from 'node-domexception';
 
 export default class _RTCPeerConnection extends EventTarget {
+    static async generateCertificate() {
+        throw new Error('Not implemented');
+    }
+
     #peerConnection;
     #localOffer;
     #localAnswer;


### PR DESCRIPTION
Adds a dummy implementation that just throws.  I don't think this is ideal for the long term but weirdly in my app we only call this method in browsers, but the app builds using the polyfill types so it needs to be present.

To implement it properly it needs an extra method exporting from libdatachannel.

Refs: https://github.com/paullouisageneau/libdatachannel/issues/972