### PR TITLE
fix: export missing polyfills

### DIFF
--- a/polyfill/RTCDataChannel.d.ts
+++ b/polyfill/RTCDataChannel.d.ts
@@ -1,6 +1,6 @@
 /// <reference lib="dom" />
 
-import NodeDataChannel from '../lib';
+import * as NodeDataChannel from '../lib/index.js';
 
 export default class _RTCDataChannel extends EventTarget implements RTCDataChannel {
     constructor(dataChannel: NodeDataChannel.DataChannel, opts: RTCDataChannelInit);

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -20,3 +20,18 @@ export {
     RTCDataChannelEvent,
     RTCPeerConnectionIceEvent,
 };
+
+declare const _default: {
+    RTCCertificate: typeof RTCCertificate;
+    RTCDataChannel: typeof RTCDataChannel;
+    RTCDtlsTransport: typeof RTCDtlsTransport;
+    RTCIceCandidate: typeof RTCIceCandidate;
+    RTCIceTransport: typeof RTCIceTransport;
+    RTCPeerConnection: typeof RTCPeerConnection;
+    RTCSctpTransport: typeof RTCSctpTransport;
+    RTCSessionDescription: typeof RTCSessionDescription;
+    RTCDataChannelEvent: typeof RTCDataChannelEvent;
+    RTCPeerConnectionIceEvent: typeof RTCPeerConnectionIceEvent;
+};
+
+export default _default;

--- a/polyfill/index.d.ts
+++ b/polyfill/index.d.ts
@@ -1,14 +1,22 @@
-import RTCPeerConnection from './RTCPeerConnection.js';
-import RTCSessionDescription from './RTCSessionDescription.js';
-import RTCIceCandidate from './RTCIceCandidate.js';
+import RTCCertificate from './RTCCertificate.js';
 import RTCDataChannel from './RTCDataChannel.js';
+import RTCDtlsTransport from './RTCDtlsTransport.js';
+import RTCIceCandidate from './RTCIceCandidate.js';
+import RTCIceTransport from './RTCIceTransport.js';
+import RTCPeerConnection from './RTCPeerConnection.js';
+import RTCSctpTransport from './RTCSctpTransport.js';
+import RTCSessionDescription from './RTCSessionDescription.js';
 import { RTCDataChannelEvent, RTCPeerConnectionIceEvent } from './Events.js';
 
 export {
-    RTCPeerConnection,
-    RTCSessionDescription,
-    RTCIceCandidate,
+    RTCCertificate,
     RTCDataChannel,
+    RTCDtlsTransport,
+    RTCIceCandidate,
+    RTCIceTransport,
+    RTCPeerConnection,
+    RTCSctpTransport,
+    RTCSessionDescription,
     RTCDataChannelEvent,
     RTCPeerConnectionIceEvent,
 };

--- a/polyfill/index.js
+++ b/polyfill/index.js
@@ -1,15 +1,14 @@
-export { default as RTCCertificate } from './RTCCertificate.js';
-export { default as RTCDataChannel } from './RTCDataChannel.js';
-export { default as RTCDtlsTransport } from './RTCDtlsTransport.js';
-export { default as RTCIceCandidate } from './RTCIceCandidate.js';
-export { default as RTCIceTransport } from './RTCIceTransport.js';
-export { default as RTCPeerConnection } from './RTCPeerConnection.js';
-export { default as RTCSctpTransport } from './RTCSctpTransport.js';
-export { default as RTCSessionDescription } from './RTCSessionDescription.js';
+import RTCCertificate from './RTCCertificate.js';
+import RTCDataChannel from './RTCDataChannel.js';
+import RTCDtlsTransport from './RTCDtlsTransport.js';
+import RTCIceCandidate from './RTCIceCandidate.js';
+import RTCIceTransport from './RTCIceTransport.js';
+import RTCPeerConnection from './RTCPeerConnection.js';
+import RTCSctpTransport from './RTCSctpTransport.js';
+import RTCSessionDescription from './RTCSessionDescription.js';
+import { RTCDataChannelEvent, RTCPeerConnectionIceEvent } from './Events.js';
 
-export { RTCDataChannelEvent, RTCPeerConnectionIceEvent } from './Events.js';
-
-export default {
+export {
     RTCCertificate,
     RTCDataChannel,
     RTCDtlsTransport,

--- a/polyfill/index.js
+++ b/polyfill/index.js
@@ -1,14 +1,23 @@
-import RTCPeerConnection from './RTCPeerConnection.js';
-import RTCSessionDescription from './RTCSessionDescription.js';
-import RTCIceCandidate from './RTCIceCandidate.js';
-import RTCDataChannel from './RTCDataChannel.js';
-import { RTCDataChannelEvent, RTCPeerConnectionIceEvent } from './Events.js';
+export { default as RTCCertificate } from './RTCCertificate.js';
+export { default as RTCDataChannel } from './RTCDataChannel.js';
+export { default as RTCDtlsTransport } from './RTCDtlsTransport.js';
+export { default as RTCIceCandidate } from './RTCIceCandidate.js';
+export { default as RTCIceTransport } from './RTCIceTransport.js';
+export { default as RTCPeerConnection } from './RTCPeerConnection.js';
+export { default as RTCSctpTransport } from './RTCSctpTransport.js';
+export { default as RTCSessionDescription } from './RTCSessionDescription.js';
+
+export { RTCDataChannelEvent, RTCPeerConnectionIceEvent } from './Events.js';
 
 export default {
-    RTCPeerConnection,
-    RTCSessionDescription,
-    RTCIceCandidate,
+    RTCCertificate,
     RTCDataChannel,
+    RTCDtlsTransport,
+    RTCIceCandidate,
+    RTCIceTransport,
+    RTCPeerConnection,
+    RTCSctpTransport,
+    RTCSessionDescription,
     RTCDataChannelEvent,
     RTCPeerConnectionIceEvent,
 };

--- a/polyfill/index.js
+++ b/polyfill/index.js
@@ -20,3 +20,16 @@ export {
     RTCDataChannelEvent,
     RTCPeerConnectionIceEvent,
 };
+
+export default {
+    RTCCertificate,
+    RTCDataChannel,
+    RTCDtlsTransport,
+    RTCIceCandidate,
+    RTCIceTransport,
+    RTCPeerConnection,
+    RTCSctpTransport,
+    RTCSessionDescription,
+    RTCDataChannelEvent,
+    RTCPeerConnectionIceEvent,
+};


### PR DESCRIPTION
I need to use `RTCSessionDescription` but it's not exported so this PR Exports all implemented polyfills.

It exports them as both named exports and properties of the default export for backwards compatibility.