### PR TITLE
Add websocket functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ FetchContent_Declare(
 )
 
 option(NO_MEDIA "Disable media transport support in libdatachannel" OFF)
-option(NO_WEBSOCKET "Disable WebSocket support in libdatachannel" ON)
+option(NO_WEBSOCKET "Disable WebSocket support in libdatachannel" OFF)
 
 FetchContent_GetProperties(libdatachannel)
 
@@ -58,6 +58,8 @@ add_library(${PROJECT_NAME} SHARED
     src/data-channel-wrapper.cpp
     src/peer-connection-wrapper.cpp
     src/thread-safe-callback.cpp
+    src/web-socket-wrapper.cpp
+    src/web-socket-server-wrapper.cpp
     src/main.cpp
     ${CMAKE_JS_SRC}
 )

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -189,11 +189,8 @@ export class Track {
     onMessage(cb: (msg: Buffer) => void): void;
 }
 
-export class DataChannel {
+export interface Channel {
     close(): void;
-    getLabel(): string;
-    getId(): number;
-    getProtocol(): string;
     sendMessage(msg: string): boolean;
     sendMessageBinary(buffer: Uint8Array): boolean;
     isOpen(): boolean;
@@ -205,6 +202,74 @@ export class DataChannel {
     onError(cb: (err: string) => void): void;
     onBufferedAmountLow(cb: () => void): void;
     onMessage(cb: (msg: string | Buffer) => void): void;
+}
+export class DataChannel implements Channel {
+    getLabel(): string;
+    getId(): number;
+    getProtocol(): string;
+
+    // Channel implementation
+    close(): void;
+    sendMessage(msg: string): boolean;
+    sendMessageBinary(buffer: Uint8Array): boolean;
+    isOpen(): boolean;
+    bufferedAmount(): number;
+    maxMessageSize(): number;
+    setBufferedAmountLowThreshold(newSize: number): void;
+    onOpen(cb: () => void): void;
+    onClosed(cb: () => void): void;
+    onError(cb: (err: string) => void): void;
+    onBufferedAmountLow(cb: () => void): void;
+    onMessage(cb: (msg: string | Buffer) => void): void;
+}
+
+export interface WebSocketConfiguration {
+    disableTlsVerification?: boolean; // default = false, if true, don't verify the TLS certificate
+    proxyServer?: ProxyServer; // only non-authenticated http supported for now
+    protocols?: string[];
+    connectionTimeout?: number; // miliseconds, zero to disable
+    pingInterval?: number; // millisecondrs, zero to disable
+    maxOutstandingPings?: number;
+    caCertificatePemFile?: string;
+    certificatePemFile?: string;
+    keyPemFile?: string;
+    keyPemPass?: string;
+    maxMessageSize: number;
+}
+export class WebSocket implements Channel {
+    constructor(config?: WebSocketConfiguration);
+
+    // Channel implementation
+    close(): void;
+    sendMessage(msg: string): boolean;
+    sendMessageBinary(buffer: Uint8Array): boolean;
+    isOpen(): boolean;
+    bufferedAmount(): number;
+    maxMessageSize(): number;
+    setBufferedAmountLowThreshold(newSize: number): void;
+    onOpen(cb: () => void): void;
+    onClosed(cb: () => void): void;
+    onError(cb: (err: string) => void): void;
+    onBufferedAmountLow(cb: () => void): void;
+    onMessage(cb: (msg: string | Buffer) => void): void;
+}
+
+export interface WebSocketServerConfiguration {
+    port?: number; // default 8080
+    enableTls?: boolean; // default = false;
+    certificatePemFile?: string;
+    keyPemFile?: string;
+    keyPemPass?: string;
+    bindAddress?: string;
+    connectionTimeout?: number; // milliseconds
+    maxMessageSize?: number;
+}
+
+export class WebSocketServer {
+    constructor(config?: WebSocketServerConfiguration);
+    port(): number;
+    stop(): void;
+    onClient(cb: (ws: WebSocket) => void): void;
 }
 
 export class PeerConnection {

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,8 @@ const {
     Audio,
     DataChannel,
     PeerConnection,
+    WebSocket,
+    WebSocketServer,
 } = nodeDataChannel;
 
 export {
@@ -29,6 +31,8 @@ export {
     Audio,
     DataChannel,
     PeerConnection,
+    WebSocket,
+    WebSocketServer,
     // Extra exports
     DataChannelStream,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "node-datachannel",
-    "version": "0.5.5",
+    "version": "0.6.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "node-datachannel",
-            "version": "0.5.3",
+            "version": "0.6.0",
             "hasInstallScript": true,
             "license": "MPL 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-datachannel",
-    "version": "0.5.5",
+    "version": "0.6.0",
     "description": "libdatachannel node bindings",
     "type": "module",
     "exports": {
@@ -44,7 +44,8 @@
         "p2p",
         "peer-to-peer",
         "datachannel",
-        "data channel"
+        "data channel",
+        "websocket"
     ],
     "contributors": [
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,8 @@
 #include "media-track-wrapper.h"
 #include "media-video-wrapper.h"
 #include "media-audio-wrapper.h"
+#include "web-socket-wrapper.h"
+#include "web-socket-server-wrapper.h"
 
 Napi::Object InitAll(Napi::Env env, Napi::Object exports)
 {
@@ -16,6 +18,8 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports)
     AudioWrapper::Init(env, exports);
     DataChannelWrapper::Init(env, exports);
     PeerConnectionWrapper::Init(env, exports);
+    WebSocketWrapper::Init(env, exports);
+    WebSocketServerWrapper::Init(env, exports);
     return exports;
 }
 

--- a/src/rtc-wrapper.cpp
+++ b/src/rtc-wrapper.cpp
@@ -2,6 +2,8 @@
 #include "peer-connection-wrapper.h"
 #include "data-channel-wrapper.h"
 #include "media-track-wrapper.h"
+#include "web-socket-wrapper.h"
+#include "web-socket-server-wrapper.h"
 
 #include "plog/Log.h"
 
@@ -116,6 +118,8 @@ void RtcWrapper::cleanup(const Napi::CallbackInfo &info)
         PeerConnectionWrapper::CloseAll();
         DataChannelWrapper::CloseAll();
         TrackWrapper::CloseAll();
+        WebSocketWrapper::CloseAll();
+        WebSocketServerWrapper::StopAll();
 
         const auto timeout = std::chrono::seconds(10);
         if (rtc::Cleanup().wait_for(std::chrono::seconds(timeout)) == std::future_status::timeout)

--- a/src/web-socket-server-wrapper.cpp
+++ b/src/web-socket-server-wrapper.cpp
@@ -1,0 +1,265 @@
+#include "web-socket-server-wrapper.h"
+
+#include "plog/Log.h"
+
+void WebSocketServerWrapper::StopAll()
+{
+    PLOG_DEBUG << "StopAll() called";
+    auto copy(instances);
+    for (auto inst : copy)
+        inst->doStop();
+}
+
+Napi::FunctionReference WebSocketServerWrapper::constructor;
+std::unordered_set<WebSocketServerWrapper *> WebSocketServerWrapper::instances;
+
+Napi::Object WebSocketServerWrapper::Init(Napi::Env env, Napi::Object exports)
+{
+    Napi::HandleScope scope(env);
+
+    Napi::Function func = DefineClass(
+        env,
+        "WebSocketServer",
+        {
+            InstanceMethod("stop", &WebSocketServerWrapper::stop),
+            InstanceMethod("port", &WebSocketServerWrapper::port),
+            InstanceMethod("onClient", &WebSocketServerWrapper::onClient)
+        });
+
+    constructor = Napi::Persistent(func);
+    constructor.SuppressDestruct();
+
+    exports.Set("WebSocketServer", func);
+    return exports;
+}
+
+WebSocketServerWrapper::WebSocketServerWrapper(const Napi::CallbackInfo &info) : Napi::ObjectWrap<WebSocketServerWrapper>(info)
+{
+    PLOG_DEBUG << "Constructor called";
+    
+    Napi::Env env = info.Env();
+
+    // Create WebSocketServer without config
+    if (info.Length() == 0)
+    {
+        try
+        {
+            PLOG_DEBUG << "Creating a new WebSocketServer without config";
+            mWebSocketServerPtr = std::make_unique<rtc::WebSocketServer>();
+        }
+        catch (std::exception &ex)
+        {
+            Napi::Error::New(env, std::string("libdatachannel error while creating WebSocketServer without config: ") + ex.what()).ThrowAsJavaScriptException();
+            return;
+        }
+ 
+        PLOG_DEBUG << "WebSocketServer created without config";
+
+        instances.insert(this);
+        return;
+    }
+
+    // Create WebSocketServer with config
+    
+    Napi::Object config = info[0].As<Napi::Object>();    
+    rtc::WebSocketServerConfiguration webSocketServerConfig;
+
+    // Port
+    if (config.Has("port"))
+    {
+        if (!config.Get("port").IsNumber()) 
+        {
+            Napi::TypeError::New(info.Env(), "port must be a number").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketServerConfig.port = config.Get("port").ToNumber().Uint32Value();
+    }
+
+    // Enable TLS
+    if (config.Has("enableTls"))
+    {
+        if (!config.Get("enableTls").IsBoolean()) 
+        {
+            Napi::TypeError::New(info.Env(), "enableTls must be boolean").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketServerConfig.enableTls = config.Get("enableTls").ToBoolean();
+    }
+
+    // Certificate PEM File
+    if (config.Has("certificatePemFile"))
+    {
+        if (!config.Get("certificatePemFile").IsString()) 
+        {
+            Napi::TypeError::New(info.Env(), "certificatePemFile must be a string").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketServerConfig.certificatePemFile = config.Get("certificatePemFile").ToString();
+    }
+
+    // Key PEM File
+    if (config.Has("keyPemFile"))
+    {
+        if (!config.Get("keyPemFile").IsString()) 
+        {
+            Napi::TypeError::New(info.Env(), "keyPemFile must be a string").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketServerConfig.keyPemFile = config.Get("keyPemFile").ToString();
+    }
+
+    // Key PEM Pass
+    if (config.Has("keyPemPass"))
+    {
+        if (!config.Get("keyPemPass").IsString()) 
+        {
+            Napi::TypeError::New(info.Env(), "keyPemPass must be a string").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketServerConfig.keyPemPass = config.Get("keyPemPass").ToString();
+    }
+
+    // Bind Address
+    if (config.Has("bindAddress"))
+    {
+        if (!config.Get("bindAddress").IsString()) 
+        {
+            Napi::TypeError::New(info.Env(), "bindAddress must be a string").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketServerConfig.bindAddress = config.Get("bindAddress").ToString();
+    }
+
+    // Connection Timeout
+    if (config.Has("connectionTimeout"))
+    {
+        if (!config.Get("connectionTimeout").IsNumber()) 
+        {
+            Napi::TypeError::New(info.Env(), "connectionTimeout must be a number").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketServerConfig.connectionTimeout = std::chrono::milliseconds(config.Get("connectionTimeout").ToNumber().Int64Value());
+    }
+
+    // Max Message Size
+    if (config.Has("maxMessageSize"))
+    {
+        if (!config.Get("maxMessageSize").IsNumber()) 
+        {
+            Napi::TypeError::New(info.Env(), "maxMessageSize must be a number").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketServerConfig.maxMessageSize = config.Get("maxMessageSize").ToNumber().Int32Value();
+    }
+
+    // Create WebSocketServer with config
+    try
+    {
+        PLOG_DEBUG << "Creating a new WebSocketServer";
+        mWebSocketServerPtr = std::make_unique<rtc::WebSocketServer>(webSocketServerConfig);
+    }
+    catch (std::exception &ex)
+    {
+        Napi::Error::New(env, std::string("libdatachannel error while creating WebSocketServer: ") + ex.what()).ThrowAsJavaScriptException();
+        return;
+    }
+ 
+    PLOG_DEBUG << "WebSocketServer created";
+    instances.insert(this);
+}
+
+WebSocketServerWrapper::~WebSocketServerWrapper()
+{
+    PLOG_DEBUG << "Destructor called";
+    doStop();
+}
+
+void WebSocketServerWrapper::doStop()
+{
+    PLOG_DEBUG << "doStop() called";
+    if (mWebSocketServerPtr)
+    {
+        PLOG_DEBUG << "Closing...";
+        try
+        {
+            mWebSocketServerPtr->stop();
+            mWebSocketServerPtr.reset();
+        }
+        catch (std::exception &ex)
+        {
+            std::cerr << std::string("libWebRtc error while closing WebSocketServer: ") + ex.what() << std::endl;
+            return;
+        }
+    }
+
+    mOnClientCallback.reset();
+
+    instances.erase(this);
+}
+
+void WebSocketServerWrapper::stop(const Napi::CallbackInfo &info)
+{
+    PLOG_DEBUG << "stop() called";
+    doStop();
+}
+
+Napi::Value WebSocketServerWrapper::port(const Napi::CallbackInfo &info)
+{
+    PLOG_DEBUG << "port() called";
+    Napi::Env env = info.Env();
+
+    if (!mWebSocketServerPtr)
+    {
+        return Napi::Number::New(info.Env(), 0);
+    }
+
+    try
+    {
+        return Napi::Number::New(info.Env(), mWebSocketServerPtr->port());
+    }
+    catch (std::exception &ex)
+    {
+        Napi::Error::New(env, std::string("WebSocketServer error: ") + ex.what()).ThrowAsJavaScriptException();
+        return Napi::Number::New(info.Env(), 0);
+    }
+}
+
+void WebSocketServerWrapper::onClient(const Napi::CallbackInfo &info)
+{
+    PLOG_DEBUG << "onClient() called";
+    Napi::Env env = info.Env();
+    int length = info.Length();
+
+    if (!mWebSocketServerPtr)
+    {
+        Napi::Error::New(env, "onClient() called on destroyed WebSocketServer").ThrowAsJavaScriptException();
+        return;
+    }
+
+    if (length < 1 || !info[0].IsFunction())
+    {
+        Napi::TypeError::New(env, "Function expected as onClient calback").ThrowAsJavaScriptException();
+        return;
+    }
+
+    // Callback
+    mOnClientCallback = std::make_unique<ThreadSafeCallback>(info[0].As<Napi::Function>());
+
+    mWebSocketServerPtr->onClient([&](std::shared_ptr<rtc::WebSocket> ws)
+                                   {
+        PLOG_DEBUG << "onClient ws received from WebSocketServer";
+        if (mOnClientCallback)
+            mOnClientCallback->call([this, ws](Napi::Env env, std::vector<napi_value> &args) {
+                PLOG_DEBUG << "mOnClientCallback call(1)";
+                // Check the WebSocketServer is not stopped
+                if(instances.find(this) == instances.end())
+                    throw ThreadSafeCallback::CancelException();
+
+                // This will run in main thread and needs to construct the
+                // arguments for the call
+                std::shared_ptr<rtc::WebSocket> webSocket = ws;
+                auto instance = WebSocketWrapper::constructor.New({Napi::External<std::shared_ptr<rtc::WebSocket>>::New(env, nullptr), Napi::External<std::shared_ptr<rtc::WebSocket>>::New(env, &webSocket)});
+                args = {instance};
+                PLOG_DEBUG << "mOnClientCallback call(2)";
+            }); });
+}

--- a/src/web-socket-server-wrapper.h
+++ b/src/web-socket-server-wrapper.h
@@ -1,0 +1,43 @@
+#ifndef WEB_SOCKET_SERVER_WRAPPER_H
+#define WEB_SOCKET_SERVER_WRAPPER_H
+
+#include <iostream>
+#include <string>
+#include <variant>
+#include <memory>
+#include <unordered_set>
+
+#include <napi.h>
+#include <rtc/rtc.hpp>
+
+#include "web-socket-wrapper.h"
+#include "thread-safe-callback.h"
+
+class WebSocketServerWrapper : public Napi::ObjectWrap<WebSocketServerWrapper>
+{
+public:
+  static Napi::FunctionReference constructor;
+  static Napi::Object Init(Napi::Env env, Napi::Object exports);
+  WebSocketServerWrapper(const Napi::CallbackInfo &info);
+  ~WebSocketServerWrapper();
+
+  // Functions
+
+  void stop(const Napi::CallbackInfo &info);
+  Napi::Value port(const Napi::CallbackInfo &info);
+
+  // Callbacks
+  void onClient(const Napi::CallbackInfo &info);
+
+  // Close all existing WebSocketServers
+  static void StopAll();
+ 
+private:
+  static std::unordered_set<WebSocketServerWrapper*> instances;
+  std::unique_ptr<rtc::WebSocketServer> mWebSocketServerPtr = nullptr;
+  std::unique_ptr<ThreadSafeCallback> mOnClientCallback = nullptr;
+
+  void doStop();
+};
+
+#endif // WEB_SOCKET_SERVER_WRAPPER_H

--- a/src/web-socket-wrapper.cpp
+++ b/src/web-socket-wrapper.cpp
@@ -1,0 +1,657 @@
+#include "web-socket-wrapper.h"
+
+#include "plog/Log.h"
+
+Napi::FunctionReference WebSocketWrapper::constructor;
+std::unordered_set<WebSocketWrapper *> WebSocketWrapper::instances;
+
+void WebSocketWrapper::CloseAll()
+{
+    PLOG_DEBUG << "CloseAll() called";
+    auto copy(instances);
+    for (auto inst : copy)
+        inst->doClose();
+}
+
+Napi::Object WebSocketWrapper::Init(Napi::Env env, Napi::Object exports)
+{
+    Napi::HandleScope scope(env);
+
+    Napi::Function func = DefineClass(
+        env,
+        "WebSocket",
+        {
+            InstanceMethod("open", &WebSocketWrapper::open),
+            InstanceMethod("close", &WebSocketWrapper::close),
+            InstanceMethod("sendMessage", &WebSocketWrapper::sendMessage),
+            InstanceMethod("sendMessageBinary", &WebSocketWrapper::sendMessageBinary),
+            InstanceMethod("isOpen", &WebSocketWrapper::isOpen),
+            InstanceMethod("bufferedAmount", &WebSocketWrapper::bufferedAmount),
+            InstanceMethod("maxMessageSize", &WebSocketWrapper::maxMessageSize),
+            InstanceMethod("setBufferedAmountLowThreshold", &WebSocketWrapper::setBufferedAmountLowThreshold),
+            InstanceMethod("onOpen", &WebSocketWrapper::onOpen),
+            InstanceMethod("onClosed", &WebSocketWrapper::onClosed),
+            InstanceMethod("onError", &WebSocketWrapper::onError),
+            InstanceMethod("onBufferedAmountLow", &WebSocketWrapper::onBufferedAmountLow),
+            InstanceMethod("onMessage", &WebSocketWrapper::onMessage),
+        });
+
+    constructor = Napi::Persistent(func);
+    constructor.SuppressDestruct();
+
+    exports.Set("WebSocket", func);
+    return exports;
+}
+
+WebSocketWrapper::WebSocketWrapper(const Napi::CallbackInfo &info) : Napi::ObjectWrap<WebSocketWrapper>(info)
+{
+    PLOG_DEBUG << "Constructor called";
+    Napi::Env env = info.Env();
+   
+    // Create WebSocket using rtc::WebSocket provided by WebSocketServer
+    if (info.Length() > 1)
+    {
+        mWebSocketPtr = *(info[1].As<Napi::External<std::shared_ptr<rtc::WebSocket>>>().Data());
+        PLOG_DEBUG << "Using WebSocket got from WebSocketServer";
+        instances.insert(this);
+        return;
+    }
+
+    // Create WebSocket without config
+    if (info.Length() == 0)
+    {
+        try
+        {
+            PLOG_DEBUG << "Creating a new WebSocket without config";
+            mWebSocketPtr = std::make_unique<rtc::WebSocket>();
+        }
+        catch (std::exception &ex)
+        {
+            Napi::Error::New(env, std::string("libdatachannel error while creating WebSocket without config: ") + ex.what()).ThrowAsJavaScriptException();
+            return;
+        }
+        instances.insert(this);
+        return;
+    }
+
+    // Create WebSocket with config
+    PLOG_DEBUG << "Creating a new WebSocket with config";
+
+    Napi::Object config = info[0].As<Napi::Object>();
+    rtc::WebSocketConfiguration webSocketConfig;
+
+   
+    if (config.Has("disableTlsVerification"))
+    {
+        if (!config.Get("disableTlsVerification").IsBoolean()) 
+        {
+            Napi::TypeError::New(info.Env(), "disableTlsVerification must be boolean").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketConfig.disableTlsVerification = config.Get("disableTlsVerification").ToBoolean();
+    }
+
+    // Proxy Server
+    if (config.Has("proxyServer")  && config.Get("proxyServer").IsObject())
+    {
+        Napi::Object proxyServer = config.Get("proxyServer").As<Napi::Object>();
+
+        // IP
+        std::string ip = proxyServer.Get("ip").As<Napi::String>();
+
+        // Port
+        uint16_t port = proxyServer.Get("port").As<Napi::Number>().Uint32Value();
+
+        // Type
+        std::string strType = proxyServer.Get("type").As<Napi::String>().ToString();
+        rtc::ProxyServer::Type type = rtc::ProxyServer::Type::Http;
+
+        if (strType == "Socks5")
+            type = rtc::ProxyServer::Type::Socks5;
+
+        // Username & Password
+        std::string username = "";
+        std::string password = "";
+
+        if (proxyServer.Get("username").IsString())
+            username = proxyServer.Get("username").As<Napi::String>().ToString();
+        if (proxyServer.Get("password").IsString())
+            username = proxyServer.Get("password").As<Napi::String>().ToString();
+
+        webSocketConfig.proxyServer = rtc::ProxyServer(type, ip, port, username, password);
+    }
+
+    if (config.Has("protocols"))
+    {
+        if (!config.Get("protocols").IsArray()) 
+        {
+            Napi::TypeError::New(info.Env(), "protocols must be an array").ThrowAsJavaScriptException();
+            return;
+        }
+        Napi::Array protocols = config.Get("protocols").As<Napi::Array>();
+        for (uint32_t i = 0; i < protocols.Length(); i++)
+        {
+            webSocketConfig.protocols.push_back(protocols.Get(i).ToString());
+        }
+    }
+    
+    if (config.Has("connectionTimeout"))
+    {
+        if (!config.Get("connectionTimeout").IsNumber()) 
+        {
+            Napi::TypeError::New(info.Env(), "connectionTimeout must be a number").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketConfig.connectionTimeout = std::chrono::milliseconds(config.Get("connectionTimeout").ToNumber().Int64Value());
+    }
+
+    if (config.Has("pingInterval"))
+    {
+        if (!config.Get("pingInterval").IsNumber()) 
+        {
+            Napi::TypeError::New(info.Env(), "pingInterval must be a number").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketConfig.pingInterval = std::chrono::milliseconds(config.Get("pingInterval").ToNumber().Int64Value());
+    }
+
+    if (config.Has("maxOutstandingPings"))
+    {
+        if (!config.Get("maxOutstandingPings").IsNumber()) 
+        {
+            Napi::TypeError::New(info.Env(), "maxOutstandingPings must be a number").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketConfig.maxOutstandingPings = config.Get("maxOutstandingPings").ToNumber().Int32Value();
+    }
+
+    if (config.Has("caCertificatePemFile"))
+    {
+        if (!config.Get("caCertificatePemFile").IsString()) 
+        {
+            Napi::TypeError::New(info.Env(), "caCertificatePemFile must be a string").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketConfig.caCertificatePemFile = config.Get("caCertificatePemFile").ToString();
+    }
+
+    if (config.Has("certificatePemFile"))
+    {
+        if (!config.Get("certificatePemFile").IsString()) 
+        {
+            Napi::TypeError::New(info.Env(), "certificatePemFile must be a string").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketConfig.certificatePemFile = config.Get("certificatePemFile").ToString();
+    }
+
+    if (config.Has("keyPemFile"))
+    {
+        if (!config.Get("keyPemFile").IsString()) 
+        {
+            Napi::TypeError::New(info.Env(), "keyPemFile must be a string").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketConfig.keyPemFile = config.Get("keyPemFile").ToString();
+    }
+
+    if (config.Has("keyPemPass"))
+    {
+        if (!config.Get("keyPemPass").IsString()) 
+        {
+            Napi::TypeError::New(info.Env(), "keyPemPass must be a string").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketConfig.keyPemPass = config.Get("keyPemPass").ToString();
+    }
+
+    if (config.Has("maxMessageSize"))
+    {
+        if (!config.Get("maxMessageSize").IsNumber()) 
+        {
+            Napi::TypeError::New(info.Env(), "maxMessageSize must be a number").ThrowAsJavaScriptException();
+            return;
+        }
+        webSocketConfig.maxMessageSize = config.Get("maxMessageSize").ToNumber().Int32Value();
+    }
+
+     // Create WebSocket
+    try
+    {
+        PLOG_DEBUG << "Creating a new WebSocket";
+        mWebSocketPtr = std::make_unique<rtc::WebSocket>(webSocketConfig);
+    }
+    catch (std::exception &ex)
+    {
+        Napi::Error::New(env, std::string("libdatachannel error while creating WebSocket: ") + ex.what()).ThrowAsJavaScriptException();
+        return;
+    }
+    
+    PLOG_DEBUG << "WebSocket created";
+    instances.insert(this);
+}
+
+WebSocketWrapper::~WebSocketWrapper()
+{
+    PLOG_DEBUG << "Destructor called";
+    doClose();
+}
+
+void WebSocketWrapper::doClose()
+{
+    PLOG_DEBUG << "doClose() called";
+    if (mWebSocketPtr)
+    {
+        PLOG_DEBUG << "Closing...";
+        try
+        {
+            mWebSocketPtr->close();
+            mWebSocketPtr.reset();
+        }
+        catch (std::exception &ex)
+        {
+            std::cerr << std::string("libWebSocket error while closing WebSocket: ") + ex.what() << std::endl;
+            return;
+        }
+    }
+
+    mOnOpenCallback.reset();
+    mOnClosedCallback.reset();
+    mOnErrorCallback.reset();
+    mOnBufferedAmountLowCallback.reset();
+    mOnMessageCallback.reset();
+
+    instances.erase(this);
+}
+
+void WebSocketWrapper::open(const Napi::CallbackInfo &info)
+{
+    PLOG_DEBUG << "open() called";
+    Napi::Env env = info.Env();
+    
+    if (!mWebSocketPtr)
+    {
+        Napi::Error::New(env, "open() called on destroyed WebSocket").ThrowAsJavaScriptException();
+        return;
+    }
+    if (info.Length() < 1 || !info[0].IsString())
+    {
+        Napi::TypeError::New(env, "url must be string").ThrowAsJavaScriptException();
+        return;
+    }
+
+    try
+    {
+        mWebSocketPtr->open(info[0].As<Napi::String>().ToString());
+    }
+    catch (std::exception &ex)
+    {
+        Napi::Error::New(env, std::string("libWebSocket error while opening WebSocket: ") + ex.what()).ThrowAsJavaScriptException();
+        return;
+    }
+}
+
+
+void WebSocketWrapper::close(const Napi::CallbackInfo &info)
+{
+    PLOG_DEBUG << "close() called";
+    doClose();
+}
+
+Napi::Value WebSocketWrapper::sendMessage(const Napi::CallbackInfo &info)
+{
+    PLOG_DEBUG << "sendMessage() called";
+    if (!mWebSocketPtr)
+    {
+        Napi::Error::New(info.Env(), "sendMessage() called on destroyed channel").ThrowAsJavaScriptException();
+        return info.Env().Null();
+    }
+
+    Napi::Env env = info.Env();
+    int length = info.Length();
+
+    // Allow call with NULL
+    if (length < 1 || (!info[0].IsString() && !info[0].IsNull()))
+    {
+        Napi::TypeError::New(env, "String or Null expected").ThrowAsJavaScriptException();
+        return info.Env().Null();
+    }
+
+    try
+    {
+        return Napi::Boolean::New(info.Env(), mWebSocketPtr->send(info[0].As<Napi::String>().ToString()));
+    }
+    catch (std::exception &ex)
+    {
+        Napi::Error::New(env, std::string("libWebSocket error while sending data channel message: ") + ex.what()).ThrowAsJavaScriptException();
+        return Napi::Boolean::New(info.Env(), false);
+    }
+}
+
+Napi::Value WebSocketWrapper::sendMessageBinary(const Napi::CallbackInfo &info)
+{
+    PLOG_DEBUG << "sendMessageBinary() called";
+    if (!mWebSocketPtr)
+    {
+        Napi::Error::New(info.Env(), "sendMessagBinary() called on destroyed channel").ThrowAsJavaScriptException();
+        return info.Env().Null();
+    }
+
+    Napi::Env env = info.Env();
+    int length = info.Length();
+
+    if (length < 1 || !info[0].IsBuffer())
+    {
+        Napi::TypeError::New(env, "Buffer expected").ThrowAsJavaScriptException();
+        return info.Env().Null();
+    }
+
+    try
+    {
+        Napi::Uint8Array buffer = info[0].As<Napi::Uint8Array>();
+        return Napi::Boolean::New(info.Env(), mWebSocketPtr->send((std::byte *)buffer.Data(), buffer.ByteLength()));
+    }
+    catch (std::exception &ex)
+    {
+        Napi::Error::New(env, std::string("libWebSocket error while sending data channel message: ") + ex.what()).ThrowAsJavaScriptException();
+        return Napi::Boolean::New(info.Env(), false);
+    }
+}
+
+Napi::Value WebSocketWrapper::isOpen(const Napi::CallbackInfo &info)
+{
+    PLOG_DEBUG << "isOpen() called";
+    Napi::Env env = info.Env();
+
+    if (!mWebSocketPtr)
+    {
+        return Napi::Boolean::New(info.Env(), false);
+    }
+
+    try
+    {
+        return Napi::Boolean::New(info.Env(), mWebSocketPtr->isOpen());
+    }
+    catch (std::exception &ex)
+    {
+        Napi::Error::New(env, std::string("libWebSocket error: ") + ex.what()).ThrowAsJavaScriptException();
+        return Napi::Boolean::New(info.Env(), false);
+    }
+}
+
+Napi::Value WebSocketWrapper::bufferedAmount(const Napi::CallbackInfo &info)
+{
+    PLOG_DEBUG << "bufferedAmount() called";
+    Napi::Env env = info.Env();
+
+    if (!mWebSocketPtr)
+    {
+        return Napi::Number::New(info.Env(), 0);
+    }
+
+    try
+    {
+        return Napi::Number::New(info.Env(), mWebSocketPtr->bufferedAmount());
+    }
+    catch (std::exception &ex)
+    {
+        Napi::Error::New(env, std::string("libWebSocket error: ") + ex.what()).ThrowAsJavaScriptException();
+        return Napi::Number::New(info.Env(), 0);
+    }
+}
+
+Napi::Value WebSocketWrapper::maxMessageSize(const Napi::CallbackInfo &info)
+{
+    PLOG_DEBUG << "maxMessageSize() called";
+    Napi::Env env = info.Env();
+
+    if (!mWebSocketPtr)
+    {
+        return Napi::Number::New(info.Env(), 0);
+    }
+
+    try
+    {
+        return Napi::Number::New(info.Env(), mWebSocketPtr->maxMessageSize());
+    }
+    catch (std::exception &ex)
+    {
+        Napi::Error::New(env, std::string("libWebSocket error: ") + ex.what()).ThrowAsJavaScriptException();
+        return Napi::Number::New(info.Env(), 0);
+    }
+}
+
+void WebSocketWrapper::setBufferedAmountLowThreshold(const Napi::CallbackInfo &info)
+{
+    PLOG_DEBUG << "setBufferedAmountLowThreshold() called";
+    if (!mWebSocketPtr)
+    {
+        Napi::Error::New(info.Env(), "setBufferedAmountLowThreshold() called on destroyed channel").ThrowAsJavaScriptException();
+        return;
+    }
+
+    Napi::Env env = info.Env();
+    int length = info.Length();
+
+    if (length < 1 || !info[0].IsNumber())
+    {
+        Napi::TypeError::New(env, "Number expected").ThrowAsJavaScriptException();
+        return;
+    }
+
+    try
+    {
+        mWebSocketPtr->setBufferedAmountLowThreshold(info[0].ToNumber().Uint32Value());
+    }
+    catch (std::exception &ex)
+    {
+        Napi::Error::New(env, std::string("libWebSocket error: ") + ex.what()).ThrowAsJavaScriptException();
+        return;
+    }
+}
+
+void WebSocketWrapper::onOpen(const Napi::CallbackInfo &info)
+{
+    PLOG_DEBUG << "new onOpen() called";
+    if (!mWebSocketPtr)
+    {
+        Napi::Error::New(info.Env(), "onOpen() called on destroyed channel").ThrowAsJavaScriptException();
+        return;
+    }
+
+    Napi::Env env = info.Env();
+    int length = info.Length();
+
+    if (length < 1 || !info[0].IsFunction())
+    {
+        Napi::TypeError::New(env, "Function expected").ThrowAsJavaScriptException();
+        return;
+    }
+
+    // Callback
+    mOnOpenCallback = std::make_unique<ThreadSafeCallback>(info[0].As<Napi::Function>());
+
+    
+    mWebSocketPtr->onOpen([&]()
+        {
+            PLOG_DEBUG << "onOpen cb received from rtc";
+            
+            if (mOnOpenCallback)
+                mOnOpenCallback->call([this](Napi::Env env, std::vector<napi_value> &args) {
+                    PLOG_DEBUG << "mOnOpenCallback call(1)";
+                    // Check the WebSocket is not closed
+                    if(instances.find(this) == instances.end()) 
+                        {
+                            PLOG_DEBUG << "WebSocket not found in instances";
+                            throw ThreadSafeCallback::CancelException();
+                        }
+                        
+
+                    // This will run in main thread and needs to construct the
+                    // arguments for the call
+                    args = {};
+                    PLOG_DEBUG << "mOnOpenCallback call(2)";
+                });
+             
+        });
+
+}
+
+void WebSocketWrapper::onClosed(const Napi::CallbackInfo &info)
+{
+    PLOG_DEBUG << "onClosed() called";
+    if (!mWebSocketPtr)
+    {
+        Napi::Error::New(info.Env(), "onClosed() called on destroyed WebSocket").ThrowAsJavaScriptException();
+        return;
+    }
+
+    Napi::Env env = info.Env();
+    int length = info.Length();
+
+    if (length < 1 || !info[0].IsFunction())
+    {
+        Napi::TypeError::New(env, "Function expected").ThrowAsJavaScriptException();
+        return;
+    }
+
+    // Callback
+    mOnClosedCallback = std::make_unique<ThreadSafeCallback>(info[0].As<Napi::Function>());
+
+    mWebSocketPtr->onClosed([&]()
+                              {
+        PLOG_DEBUG << "onClosed cb received from rtc";
+        if (mOnClosedCallback)
+            mOnClosedCallback->call([this](Napi::Env env, std::vector<napi_value> &args) {
+                PLOG_DEBUG << "mOnClosedCallback call";
+                // Do not check if the data channel has been closed here
+
+                // This will run in main thread and needs to construct the
+                // arguments for the call
+                args = {};
+            }); });
+}
+
+void WebSocketWrapper::onError(const Napi::CallbackInfo &info)
+{
+    PLOG_DEBUG << "onError() called";
+    if (!mWebSocketPtr)
+    {
+        Napi::Error::New(info.Env(), "onError() called on destroyed channel").ThrowAsJavaScriptException();
+        return;
+    }
+
+    Napi::Env env = info.Env();
+    int length = info.Length();
+
+    if (length < 1 || !info[0].IsFunction())
+    {
+        Napi::TypeError::New(env, "Function expected").ThrowAsJavaScriptException();
+        return;
+    }
+
+    // Callback
+    mOnErrorCallback = std::make_unique<ThreadSafeCallback>(info[0].As<Napi::Function>());
+
+    mWebSocketPtr->onError([&](std::string error)
+                             {
+        PLOG_DEBUG << "onError cb received from rtc";
+        if (mOnErrorCallback)
+            mOnErrorCallback->call([this, error = std::move(error)](Napi::Env env, std::vector<napi_value> &args) {
+                PLOG_DEBUG << "mOnErrorCallback call(1)";
+                // Check the data channel is not closed
+                if(instances.find(this) == instances.end())
+                    throw ThreadSafeCallback::CancelException();
+
+                // This will run in main thread and needs to construct the
+                // arguments for the call
+                args = {Napi::String::New(env, error)};
+                PLOG_DEBUG << "mOnErrorCallback call(2)";
+            }); });
+}
+
+void WebSocketWrapper::onBufferedAmountLow(const Napi::CallbackInfo &info)
+{
+    PLOG_DEBUG << "onBufferedAmountLow() called";
+    if (!mWebSocketPtr)
+    {
+        Napi::Error::New(info.Env(), "onBufferedAmountLow() called on destroyed channel").ThrowAsJavaScriptException();
+        return;
+    }
+
+    Napi::Env env = info.Env();
+    int length = info.Length();
+
+    if (length < 1 || !info[0].IsFunction())
+    {
+        Napi::TypeError::New(env, "Function expected").ThrowAsJavaScriptException();
+        return;
+    }
+
+    // Callback
+    mOnBufferedAmountLowCallback = std::make_unique<ThreadSafeCallback>(info[0].As<Napi::Function>());
+
+    mWebSocketPtr->onBufferedAmountLow([&]()
+                                         {
+        PLOG_DEBUG << "onBufferedAmountLow cb received from rtc";
+        if (mOnBufferedAmountLowCallback)
+            mOnBufferedAmountLowCallback->call([this](Napi::Env env, std::vector<napi_value> &args) {
+                PLOG_DEBUG << "mOnBufferedAmountLowCallback call(1)";
+                // Check the data channel is not closed
+                if(instances.find(this) == instances.end())
+                    throw ThreadSafeCallback::CancelException();
+
+                // This will run in main thread and needs to construct the
+                // arguments for the call
+                args = {};
+                PLOG_DEBUG << "mOnBufferedAmountLowCallback call(2)";
+            }); });
+}
+
+void WebSocketWrapper::onMessage(const Napi::CallbackInfo &info)
+{
+    PLOG_DEBUG << "onMessage() called";
+    if (!mWebSocketPtr)
+    {
+        Napi::Error::New(info.Env(), "onMessage() called on destroyed channel").ThrowAsJavaScriptException();
+        return;
+    }
+
+    Napi::Env env = info.Env();
+    int length = info.Length();
+
+    if (length < 1 || !info[0].IsFunction())
+    {
+        Napi::TypeError::New(env, "Function expected").ThrowAsJavaScriptException();
+        return;
+    }
+
+    // Callback
+    mOnMessageCallback = std::make_unique<ThreadSafeCallback>(info[0].As<Napi::Function>());
+
+
+     PLOG_DEBUG << "setting onMessage cb on mWebSocketPtr";
+    mWebSocketPtr->onMessage([&](std::variant<rtc::binary, std::string> message)
+                               {
+        PLOG_DEBUG << "onMessage cb received from rtc";
+        if (mOnMessageCallback)
+            mOnMessageCallback->call([this, message = std::move(message)](Napi::Env env, std::vector<napi_value> &args) {
+                PLOG_DEBUG << "mOnMessageCallback call(1)";
+                // Check the data channel is not closed
+                if(instances.find(this) == instances.end())
+                    throw ThreadSafeCallback::CancelException();
+
+                // This will run in main thread and needs to construct the
+                // arguments for the call
+                if (std::holds_alternative<std::string>(message))
+                {
+                    args = {Napi::String::New(env, std::get<std::string>(message))};
+                }
+                else
+                {
+                    auto bin = std::get<rtc::binary>(std::move(message));
+                    args = {Napi::Buffer<std::byte>::Copy(env, bin.data(), bin.size())};
+                }
+                PLOG_DEBUG << "mOnMessageCallback call(2)";
+            }); });
+}

--- a/src/web-socket-wrapper.h
+++ b/src/web-socket-wrapper.h
@@ -1,0 +1,58 @@
+#ifndef WEB_SOCKET_WRAPPER_H
+#define WEB_SOCKET_WRAPPER_H
+
+#include <iostream>
+#include <string>
+#include <variant>
+#include <memory>
+#include <unordered_set>
+
+#include <napi.h>
+#include <rtc/rtc.hpp>
+
+#include "thread-safe-callback.h"
+
+class WebSocketWrapper : public Napi::ObjectWrap<WebSocketWrapper>
+{
+public:
+  static Napi::FunctionReference constructor;
+  static Napi::Object Init(Napi::Env env, Napi::Object exports);
+  WebSocketWrapper(const Napi::CallbackInfo &info);
+  ~WebSocketWrapper();
+
+  // Functions
+  void open(const Napi::CallbackInfo &info);
+  void close(const Napi::CallbackInfo &info); 
+  Napi::Value sendMessage(const Napi::CallbackInfo &info);
+  Napi::Value sendMessageBinary(const Napi::CallbackInfo &info);
+  Napi::Value isOpen(const Napi::CallbackInfo &info);
+  Napi::Value bufferedAmount(const Napi::CallbackInfo &info);
+  Napi::Value maxMessageSize(const Napi::CallbackInfo &info);
+  void setBufferedAmountLowThreshold(const Napi::CallbackInfo &info);
+
+  // Callbacks
+  void onOpen(const Napi::CallbackInfo &info);
+  void onClosed(const Napi::CallbackInfo &info);
+  void onError(const Napi::CallbackInfo &info);
+  void onBufferedAmountLow(const Napi::CallbackInfo &info);
+  void onMessage(const Napi::CallbackInfo &info);
+
+  // Close all existing WebSockets
+  static void CloseAll();
+
+private:
+  static std::unordered_set<WebSocketWrapper*> instances;
+
+  void doClose();
+
+  std::shared_ptr<rtc::WebSocket> mWebSocketPtr = nullptr;
+
+  // Callback Ptrs
+  std::unique_ptr<ThreadSafeCallback> mOnOpenCallback = nullptr;
+  std::unique_ptr<ThreadSafeCallback> mOnClosedCallback = nullptr;
+  std::unique_ptr<ThreadSafeCallback> mOnErrorCallback = nullptr;
+  std::unique_ptr<ThreadSafeCallback> mOnBufferedAmountLowCallback = nullptr;
+  std::unique_ptr<ThreadSafeCallback> mOnMessageCallback = nullptr;
+};
+
+#endif // WEB_SOCKET_WRAPPER_H

--- a/test/websockets.js
+++ b/test/websockets.js
@@ -1,0 +1,48 @@
+import nodeDataChannel from '../lib/index.js';
+
+nodeDataChannel.initLogger('Debug');
+nodeDataChannel.preload();
+
+const webSocketServer = new nodeDataChannel.WebSocketServer({ bindAddress: '127.0.0.1', port: 1987 });
+
+webSocketServer.onClient((serverSocket) => {
+    console.error('webSocketServer.onClient()');
+
+    serverSocket.onOpen(() => {
+        console.error('serverSocket.onOpen()');
+    });
+
+    serverSocket.onMessage((message) => {
+        console.error('serverSocket.onMessage():', message);
+        serverSocket.sendMessage('reply to' + message);
+    });
+
+    serverSocket.onClosed(() => {
+        console.error('serverSocket.onClosed()');
+        serverSocket.close();
+    });
+});
+
+const clientSocket = new nodeDataChannel.WebSocket();
+
+clientSocket.onOpen(() => {
+    console.error('clientSocket.onOpen()');
+    clientSocket.sendMessage('Hello');
+});
+
+clientSocket.onMessage((message) => {
+    console.error('clientSocket.onMessage():', message);
+    clientSocket.close();
+    webSocketServer.stop();
+});
+
+clientSocket.onClosed(() => {
+    console.error('clientSocket.onClosed()');
+    clientSocket.close();
+});
+
+clientSocket.open('ws://127.0.0.1:1987');
+
+setTimeout(() => {
+    nodeDataChannel.cleanup();
+}, 1000);


### PR DESCRIPTION
Expose the WebSocket functionality of libdatachannel in node-datachannel

* Change the compilation options of libdatachannel to enable WebSocket functionality
* New Classes WebSocket and WebSocketServer
* Simple websockets.js test
* Typescript typings in which both DataChannel and WebSocket implement a common Channel interface so users can handle them in an uniform manner
 
ToDo:

* WebSocket implementation is, for most part, a cut-and-paste from DataChannel functionality, maybe we should extract the  common functionality into a superclass? 
* Add jest tests