### PR TITLE
Add missing websocket functions

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -238,6 +238,10 @@ export interface WebSocketConfiguration {
 }
 export class WebSocket implements Channel {
     constructor(config?: WebSocketConfiguration);
+    open(url: string): void;
+    forceClose(): void;
+    remoteAddress(): string | undefined;
+    path(): string | undefined;
 
     // Channel implementation
     close(): void;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "node-datachannel",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "node-datachannel",
-            "version": "0.6.0",
+            "version": "0.7.1",
             "hasInstallScript": true,
             "license": "MPL 2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-datachannel",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "libdatachannel node bindings",
     "type": "module",
     "exports": {

--- a/src/web-socket-wrapper.h
+++ b/src/web-socket-wrapper.h
@@ -23,12 +23,15 @@ public:
   // Functions
   void open(const Napi::CallbackInfo &info);
   void close(const Napi::CallbackInfo &info);
+  void forceClose(const Napi::CallbackInfo &info);
   Napi::Value sendMessage(const Napi::CallbackInfo &info);
   Napi::Value sendMessageBinary(const Napi::CallbackInfo &info);
   Napi::Value isOpen(const Napi::CallbackInfo &info);
   Napi::Value bufferedAmount(const Napi::CallbackInfo &info);
   Napi::Value maxMessageSize(const Napi::CallbackInfo &info);
   void setBufferedAmountLowThreshold(const Napi::CallbackInfo &info);
+  Napi::Value remoteAddress(const Napi::CallbackInfo &info);
+  Napi::Value path(const Napi::CallbackInfo &info);
 
   // Callbacks
   void onOpen(const Napi::CallbackInfo &info);
@@ -47,6 +50,7 @@ private:
   static std::unordered_set<WebSocketWrapper *> instances;
 
   void doClose();
+  void doForceClose();
   void doCleanup();
 
   std::shared_ptr<rtc::WebSocket> mWebSocketPtr = nullptr;

--- a/test/websockets.js
+++ b/test/websockets.js
@@ -6,7 +6,9 @@ nodeDataChannel.preload();
 const webSocketServer = new nodeDataChannel.WebSocketServer({ bindAddress: '127.0.0.1', port: 1987 });
 
 webSocketServer.onClient((serverSocket) => {
-    console.log('webSocketServer.onClient()');
+    console.log(
+        'webSocketServer.onClient() remoteAddress: ' + serverSocket.remoteAddress() + ', path: ' + serverSocket.path(),
+    );
 
     serverSocket.onOpen(() => {
         console.log('serverSocket.onOpen()');
@@ -32,7 +34,7 @@ clientSocket.onOpen(() => {
 
 clientSocket.onMessage((message) => {
     console.log('clientSocket.onMessage():', message);
-    clientSocket.close();
+    clientSocket.forceClose();
     webSocketServer.stop();
 });
 


### PR DESCRIPTION
* Make the libdatachannel WebSocket support complete by adding the previously-missing functions to the WebSocket class:

```typescript
     forceClose(): void;
     remoteAddress(): string | undefined;
     path(): string | undefined; 
```

* Add missing `open(string: url)` function to the typescript typings of WebSocket
* Replace 'libWebSocket' -> 'libdatachannel' in debug logging