### PR TITLE
Fix ThreadSafeCallback context and cleanup

### DIFF
--- a/src/data-channel-wrapper.cpp
+++ b/src/data-channel-wrapper.cpp
@@ -58,6 +58,10 @@ DataChannelWrapper::DataChannelWrapper(const Napi::CallbackInfo &info) : Napi::O
     PLOG_DEBUG << "Constructor called";
     mDataChannelPtr = *(info[0].As<Napi::External<std::shared_ptr<rtc::DataChannel>>>().Data());
     PLOG_DEBUG << "Data Channel created";
+
+    // Closed callback must be set to trigger cleanup
+    mOnClosedCallback = std::make_unique<ThreadSafeCallback>(Napi::Function::New(info.Env(), [](const Napi::CallbackInfo&){}));
+
     instances.insert(this);
 }
 

--- a/src/media-track-wrapper.cpp
+++ b/src/media-track-wrapper.cpp
@@ -56,7 +56,12 @@ Napi::Object TrackWrapper::Init(Napi::Env env, Napi::Object exports)
 
 TrackWrapper::TrackWrapper(const Napi::CallbackInfo &info) : Napi::ObjectWrap<TrackWrapper>(info)
 {
+    PLOG_DEBUG << "Constructor called";
     mTrackPtr = *(info[0].As<Napi::External<std::shared_ptr<rtc::Track>>>().Data());
+    PLOG_DEBUG << "Track created";
+
+    // Closed callback must be set to trigger cleanup
+    mOnClosedCallback = std::make_unique<ThreadSafeCallback>(Napi::Function::New(info.Env(), [](const Napi::CallbackInfo&){}));
 
     instances.insert(this);
 }

--- a/src/peer-connection-wrapper.cpp
+++ b/src/peer-connection-wrapper.cpp
@@ -237,7 +237,7 @@ PeerConnectionWrapper::PeerConnectionWrapper(const Napi::CallbackInfo &info) : N
     // Create peer-connection
     try
     {
-        PLOG_DEBUG << "Creating a new peer";
+        PLOG_DEBUG << "Creating a new Peer Connection";
         mRtcPeerConnPtr = std::make_unique<rtc::PeerConnection>(rtcConfig);
     }
     catch (std::exception &ex)
@@ -245,6 +245,11 @@ PeerConnectionWrapper::PeerConnectionWrapper(const Napi::CallbackInfo &info) : N
         Napi::Error::New(env, std::string("libdatachannel error while creating peer connection: ") + ex.what()).ThrowAsJavaScriptException();
         return;
     }
+
+    PLOG_DEBUG << "Peer Connection created";
+
+    // State change callback must be set to trigger cleanup on close
+    mOnStateChangeCallback = std::make_unique<ThreadSafeCallback>(Napi::Function::New(info.Env(), [](const Napi::CallbackInfo&){}));
 
     instances.insert(this);
 }

--- a/src/thread-safe-callback.cpp
+++ b/src/thread-safe-callback.cpp
@@ -41,7 +41,7 @@ void ThreadSafeCallback::callbackFunc(Napi::Env env,
                                       ContextType *context,
                                       CallbackData *data)
 {
-    // if env is gone this could mean cb fn has changed. See issue#176
+    // if env is gone, it could mean this cb was destroyed. See issue#176
     if (!data || !env)
         return;
 
@@ -59,9 +59,10 @@ void ThreadSafeCallback::callbackFunc(Napi::Env env,
         return;
     }
 
-    if (env && callback)
+    if (callback)
     {
         callback.Call(args);
-        cleanup();
     }
+
+    cleanup();
 }

--- a/src/thread-safe-callback.cpp
+++ b/src/thread-safe-callback.cpp
@@ -9,16 +9,16 @@ const char *ThreadSafeCallback::CancelException::what() const throw()
 
 ThreadSafeCallback::ThreadSafeCallback(Napi::Function callback)
 {
-    if (!callback.IsFunction())
-        throw Napi::Error::New(callback.Env(), "Callback must be a function");
-
     Napi::Env env = callback.Env();
 
-    receiver = Napi::Persistent(static_cast<Napi::Value>(Napi::Object::New(env)));
+    if (!callback.IsFunction())
+        throw Napi::Error::New(env, "Callback must be a function");
+
     tsfn = tsfn_t::New(env,
                        std::move(callback),
                        "ThreadSafeCallback callback",
-                       0, 1, &receiver);
+                       0, // unlimited queue
+                       1);
 }
 
 ThreadSafeCallback::~ThreadSafeCallback()
@@ -38,7 +38,7 @@ void ThreadSafeCallback::call(arg_func_t argFunc, cleanup_func_t cleanupFunc)
 
 void ThreadSafeCallback::callbackFunc(Napi::Env env,
                                       Napi::Function callback,
-                                      Napi::Reference<Napi::Value> *context,
+                                      ContextType *context,
                                       CallbackData *data)
 {
     // if env is gone this could mean cb fn has changed. See issue#176
@@ -61,7 +61,7 @@ void ThreadSafeCallback::callbackFunc(Napi::Env env,
 
     if (env && callback)
     {
-        callback.Call(context->Value(), args);
+        callback.Call(args);
         cleanup();
     }
 }

--- a/src/thread-safe-callback.h
+++ b/src/thread-safe-callback.h
@@ -30,6 +30,7 @@ public:
     };
 
 private:
+    using ContextType = std::nullptr_t;
     struct CallbackData
     {
         arg_func_t argFunc;
@@ -38,12 +39,10 @@ private:
 
     static void callbackFunc(Napi::Env env,
                              Napi::Function callback,
-                             Napi::Reference<Napi::Value> *context,
+                             ContextType *context,
                              CallbackData *data);
 
-    using tsfn_t = Napi::TypedThreadSafeFunction<Napi::Reference<Napi::Value>, CallbackData, callbackFunc>;
-
-    Napi::Reference<Napi::Value> receiver;
+    using tsfn_t = Napi::TypedThreadSafeFunction<ContextType, CallbackData, callbackFunc>;
     tsfn_t tsfn;
 };
 

--- a/src/web-socket-wrapper.cpp
+++ b/src/web-socket-wrapper.cpp
@@ -238,6 +238,10 @@ WebSocketWrapper::WebSocketWrapper(const Napi::CallbackInfo &info) : Napi::Objec
     }
 
     PLOG_DEBUG << "WebSocket created";
+
+    // Closed callback must set to trigger cleanup
+    mOnClosedCallback = std::make_unique<ThreadSafeCallback>(Napi::Function::New(info.Env(), [](const Napi::CallbackInfo&){}));
+
     instances.insert(this);
 }
 
@@ -471,7 +475,7 @@ Napi::Value WebSocketWrapper::remoteAddress(const Napi::CallbackInfo &info)
 
     if (!mWebSocketPtr)
     {
-        return env.Undefined(); 
+        return env.Undefined();
     }
 
     try
@@ -500,7 +504,7 @@ Napi::Value WebSocketWrapper::path(const Napi::CallbackInfo &info)
 
     if (!mWebSocketPtr)
     {
-        return env.Undefined(); 
+        return env.Undefined();
     }
 
     try


### PR DESCRIPTION
This PR fixes two issues related to `ThreadSafeCallback`:
- It removes the callback context, which caused segfaults due to env becoming invalid (it should fix https://github.com/murat-dogan/node-datachannel/issues/245). The context seems useless as callback are not expected to be bound.
- It ensures cleanup is always called, even when the user doesn't set a closed callback, by setting dummy callbacks (fix after the close process redesign in https://github.com/murat-dogan/node-datachannel/pull/239). You can check that Jest doesn't report open handles anymore for `dc1` and `peer2` in `p2p.test.js` after running tests.