### PR TITLE
Update wrapper for deprecated methods in libdatachannel

### DIFF
--- a/src/media-audio-wrapper.cpp
+++ b/src/media-audio-wrapper.cpp
@@ -390,9 +390,8 @@ void AudioWrapper::setBitrate(const Napi::CallbackInfo &info)
         return;
     }
 
-    int bitRate = static_cast<int>(info[0].As<Napi::Number>().ToNumber());
-
-    mAudioPtr->setBitrate(bitRate);
+    unsigned int bitrate = static_cast<uint32_t>(info[0].As<Napi::Number>().ToNumber());
+    mAudioPtr->setBitrate(bitrate);
 }
 
 Napi::Value AudioWrapper::getBitrate(const Napi::CallbackInfo &info)
@@ -428,9 +427,9 @@ void AudioWrapper::addRTXCodec(const Napi::CallbackInfo &info)
         return;
     }
 
-    unsigned int payloadType = static_cast<unsigned int>(info[0].As<Napi::Number>().ToNumber());
-    unsigned int originalPayloadType = static_cast<unsigned int>(info[1].As<Napi::Number>().ToNumber());
-    unsigned int clockRate = static_cast<unsigned int>(info[2].As<Napi::Number>().ToNumber());
+    int payloadType = static_cast<int32_t>(info[0].As<Napi::Number>().ToNumber());
+    int originalPayloadType = static_cast<int32_t>(info[1].As<Napi::Number>().ToNumber());
+    unsigned int clockRate = static_cast<uint32_t>(info[2].As<Napi::Number>().ToNumber());
 
     mAudioPtr->addRtxCodec(payloadType, originalPayloadType, clockRate);
 }

--- a/src/media-rtcpreceivingsession-wrapper.cpp
+++ b/src/media-rtcpreceivingsession-wrapper.cpp
@@ -51,9 +51,8 @@ void RtcpReceivingSessionWrapper::requestBitrate(const Napi::CallbackInfo &info)
         return;
     }
 
-    unsigned int bitRate = static_cast<unsigned int>(info[0].As<Napi::Number>().ToNumber());
-
-    mSessionPtr->requestBitrate(bitRate);
+    unsigned int bitrate = static_cast<uint32_t>(info[0].As<Napi::Number>().ToNumber());
+    mSessionPtr->requestBitrate(bitrate);
 }
 
 Napi::Value RtcpReceivingSessionWrapper::requestKeyframe(const Napi::CallbackInfo &info)

--- a/src/media-track-wrapper.cpp
+++ b/src/media-track-wrapper.cpp
@@ -39,6 +39,7 @@ Napi::Object TrackWrapper::Init(Napi::Env env, Napi::Object exports)
             InstanceMethod("isOpen", &TrackWrapper::isOpen),
             InstanceMethod("isClosed", &TrackWrapper::isClosed),
             InstanceMethod("maxMessageSize", &TrackWrapper::maxMessageSize),
+            InstanceMethod("requestBitrate", &TrackWrapper::requestBitrate),
             InstanceMethod("requestKeyframe", &TrackWrapper::requestKeyframe),
             InstanceMethod("setMediaHandler", &TrackWrapper::setMediaHandler),
             InstanceMethod("onOpen", &TrackWrapper::onOpen),
@@ -235,6 +236,27 @@ Napi::Value TrackWrapper::maxMessageSize(const Napi::CallbackInfo &info)
         Napi::Error::New(env, std::string("libdatachannel error: ") + ex.what()).ThrowAsJavaScriptException();
         return Napi::Number::New(info.Env(), 0);
     }
+}
+
+Napi::Value TrackWrapper::requestBitrate(const Napi::CallbackInfo &info)
+{
+    if (!mTrackPtr)
+    {
+        Napi::Error::New(info.Env(), "requestBitrate() called on destroyed track").ThrowAsJavaScriptException();
+        return info.Env().Null();
+    }
+
+    Napi::Env env = info.Env();
+    int length = info.Length();
+
+    if (length < 1 || !info[0].IsNumber())
+    {
+        Napi::TypeError::New(env, "Number expected").ThrowAsJavaScriptException();
+        return info.Env().Null();
+    }
+
+    unsigned int bitrate = static_cast<uint32_t>(info[0].As<Napi::Number>());
+    return Napi::Boolean::New(env, mTrackPtr->requestBitrate(bitrate));
 }
 
 Napi::Value TrackWrapper::requestKeyframe(const Napi::CallbackInfo &info)

--- a/src/media-track-wrapper.h
+++ b/src/media-track-wrapper.h
@@ -30,6 +30,7 @@ public:
   Napi::Value isOpen(const Napi::CallbackInfo &info);
   Napi::Value isClosed(const Napi::CallbackInfo &info);
   Napi::Value maxMessageSize(const Napi::CallbackInfo &info);
+  Napi::Value requestBitrate(const Napi::CallbackInfo &info);
   Napi::Value requestKeyframe(const Napi::CallbackInfo &info);
   void setMediaHandler(const Napi::CallbackInfo &info);
 

--- a/src/media-video-wrapper.cpp
+++ b/src/media-video-wrapper.cpp
@@ -423,14 +423,12 @@ void VideoWrapper::setBitrate(const Napi::CallbackInfo &info)
         return;
     }
 
-    int bitRate = static_cast<int>(info[0].As<Napi::Number>().ToNumber());
-
-    mVideoPtr->setBitrate(bitRate);
+    unsigned int bitrate = info[0].As<Napi::Number>().ToNumber().Uint32Value();
+    mVideoPtr->setBitrate(bitrate);
 }
 
 Napi::Value VideoWrapper::getBitrate(const Napi::CallbackInfo &info)
 {
-
     return Napi::Number::New(info.Env(), mVideoPtr->bitrate());
 }
 
@@ -445,7 +443,7 @@ Napi::Value VideoWrapper::hasPayloadType(const Napi::CallbackInfo &info)
         return env.Null();
     }
 
-    int payloadType = static_cast<int>(info[0].As<Napi::Number>().ToNumber());
+    int payloadType = static_cast<int32_t>(info[0].As<Napi::Number>().ToNumber());
 
     return Napi::Boolean::New(env, mVideoPtr->hasPayloadType(payloadType));
 }
@@ -461,9 +459,9 @@ void VideoWrapper::addRTXCodec(const Napi::CallbackInfo &info)
         return;
     }
 
-    unsigned int payloadType = static_cast<unsigned int>(info[0].As<Napi::Number>().ToNumber());
-    unsigned int originalPayloadType = static_cast<unsigned int>(info[1].As<Napi::Number>().ToNumber());
-    unsigned int clockRate = static_cast<unsigned int>(info[2].As<Napi::Number>().ToNumber());
+    int payloadType = static_cast<int32_t>(info[0].As<Napi::Number>().ToNumber());
+    int originalPayloadType = static_cast<int32_t>(info[1].As<Napi::Number>().ToNumber());
+    unsigned int clockRate = static_cast<uint32_t>(info[2].As<Napi::Number>().ToNumber());
 
     mVideoPtr->addRtxCodec(payloadType, originalPayloadType, clockRate);
 }


### PR DESCRIPTION
This PR updates the wrapper for deprecated methods in libdatachannel, in particular the new datachannel reliability should be called instead of the legacy one for `maxPacketLifeTime` and `maxRetransmits`. It also fixes a few integer conversions on the way (`Napi::Number` isn't guaranteed to have conversion operators for integers other that `int32_t`, `uint32_t`, and `int64_t`).

This doesn't break compatibility since I haven't removed any exposed method.