### PR TITLE
fix: make rollup a dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,7 @@
             "license": "MPL 2.0",
             "dependencies": {
                 "node-domexception": "^2.0.1",
-                "prebuild-install": "^7.0.1",
-                "rollup": "^4.14.1"
+                "prebuild-install": "^7.0.1"
             },
             "devDependencies": {
                 "@types/node": "^20.6.1",
@@ -26,6 +25,7 @@
                 "node-addon-api": "^7.0.0",
                 "prebuild": "^12.0.0",
                 "prettier": "^2.8.8",
+                "rollup": "^4.14.1",
                 "typescript": "^5.3.2"
             },
             "engines": {
@@ -1408,6 +1408,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "android"
@@ -1420,6 +1421,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "android"
@@ -1432,6 +1434,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "darwin"
@@ -1444,6 +1447,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "darwin"
@@ -1456,6 +1460,7 @@
             "cpu": [
                 "arm"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -1468,6 +1473,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -1480,6 +1486,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -1492,6 +1499,7 @@
             "cpu": [
                 "ppc64le"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -1504,6 +1512,7 @@
             "cpu": [
                 "riscv64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -1516,6 +1525,7 @@
             "cpu": [
                 "s390x"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -1528,6 +1538,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -1540,6 +1551,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "linux"
@@ -1552,6 +1564,7 @@
             "cpu": [
                 "arm64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -1564,6 +1577,7 @@
             "cpu": [
                 "ia32"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -1576,6 +1590,7 @@
             "cpu": [
                 "x64"
             ],
+            "dev": true,
             "optional": true,
             "os": [
                 "win32"
@@ -1649,7 +1664,8 @@
         "node_modules/@types/estree": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+            "dev": true
         },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.6",
@@ -3955,6 +3971,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
             "hasInstallScript": true,
             "optional": true,
             "os": [
@@ -7676,6 +7693,7 @@
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.1.tgz",
             "integrity": "sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==",
+            "dev": true,
             "dependencies": {
                 "@types/estree": "1.0.5"
             },
@@ -9935,90 +9953,105 @@
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.14.1.tgz",
             "integrity": "sha512-fH8/o8nSUek8ceQnT7K4EQbSiV7jgkHq81m9lWZFIXjJ7lJzpWXbQFpT/Zh6OZYnpFykvzC3fbEvEAFZu03dPA==",
+            "dev": true,
             "optional": true
         },
         "@rollup/rollup-android-arm64": {
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.14.1.tgz",
             "integrity": "sha512-Y/9OHLjzkunF+KGEoJr3heiD5X9OLa8sbT1lm0NYeKyaM3oMhhQFvPB0bNZYJwlq93j8Z6wSxh9+cyKQaxS7PQ==",
+            "dev": true,
             "optional": true
         },
         "@rollup/rollup-darwin-arm64": {
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.14.1.tgz",
             "integrity": "sha512-+kecg3FY84WadgcuSVm6llrABOdQAEbNdnpi5X3UwWiFVhZIZvKgGrF7kmLguvxHNQy+UuRV66cLVl3S+Rkt+Q==",
+            "dev": true,
             "optional": true
         },
         "@rollup/rollup-darwin-x64": {
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.14.1.tgz",
             "integrity": "sha512-2pYRzEjVqq2TB/UNv47BV/8vQiXkFGVmPFwJb+1E0IFFZbIX8/jo1olxqqMbo6xCXf8kabANhp5bzCij2tFLUA==",
+            "dev": true,
             "optional": true
         },
         "@rollup/rollup-linux-arm-gnueabihf": {
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.14.1.tgz",
             "integrity": "sha512-mS6wQ6Do6/wmrF9aTFVpIJ3/IDXhg1EZcQFYHZLHqw6AzMBjTHWnCG35HxSqUNphh0EHqSM6wRTT8HsL1C0x5g==",
+            "dev": true,
             "optional": true
         },
         "@rollup/rollup-linux-arm64-gnu": {
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.14.1.tgz",
             "integrity": "sha512-p9rGKYkHdFMzhckOTFubfxgyIO1vw//7IIjBBRVzyZebWlzRLeNhqxuSaZ7kCEKVkm/kuC9fVRW9HkC/zNRG2w==",
+            "dev": true,
             "optional": true
         },
         "@rollup/rollup-linux-arm64-musl": {
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.14.1.tgz",
             "integrity": "sha512-nDY6Yz5xS/Y4M2i9JLQd3Rofh5OR8Bn8qe3Mv/qCVpHFlwtZSBYSPaU4mrGazWkXrdQ98GB//H0BirGR/SKFSw==",
+            "dev": true,
             "optional": true
         },
         "@rollup/rollup-linux-powerpc64le-gnu": {
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.14.1.tgz",
             "integrity": "sha512-im7HE4VBL+aDswvcmfx88Mp1soqL9OBsdDBU8NqDEYtkri0qV0THhQsvZtZeNNlLeCUQ16PZyv7cqutjDF35qw==",
+            "dev": true,
             "optional": true
         },
         "@rollup/rollup-linux-riscv64-gnu": {
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.14.1.tgz",
             "integrity": "sha512-RWdiHuAxWmzPJgaHJdpvUUlDz8sdQz4P2uv367T2JocdDa98iRw2UjIJ4QxSyt077mXZT2X6pKfT2iYtVEvOFw==",
+            "dev": true,
             "optional": true
         },
         "@rollup/rollup-linux-s390x-gnu": {
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.14.1.tgz",
             "integrity": "sha512-VMgaGQ5zRX6ZqV/fas65/sUGc9cPmsntq2FiGmayW9KMNfWVG/j0BAqImvU4KTeOOgYSf1F+k6at1UfNONuNjA==",
+            "dev": true,
             "optional": true
         },
         "@rollup/rollup-linux-x64-gnu": {
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.14.1.tgz",
             "integrity": "sha512-9Q7DGjZN+hTdJomaQ3Iub4m6VPu1r94bmK2z3UeWP3dGUecRC54tmVu9vKHTm1bOt3ASoYtEz6JSRLFzrysKlA==",
+            "dev": true,
             "optional": true
         },
         "@rollup/rollup-linux-x64-musl": {
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.14.1.tgz",
             "integrity": "sha512-JNEG/Ti55413SsreTguSx0LOVKX902OfXIKVg+TCXO6Gjans/k9O6ww9q3oLGjNDaTLxM+IHFMeXy/0RXL5R/g==",
+            "dev": true,
             "optional": true
         },
         "@rollup/rollup-win32-arm64-msvc": {
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.14.1.tgz",
             "integrity": "sha512-ryS22I9y0mumlLNwDFYZRDFLwWh3aKaC72CWjFcFvxK0U6v/mOkM5Up1bTbCRAhv3kEIwW2ajROegCIQViUCeA==",
+            "dev": true,
             "optional": true
         },
         "@rollup/rollup-win32-ia32-msvc": {
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.14.1.tgz",
             "integrity": "sha512-TdloItiGk+T0mTxKx7Hp279xy30LspMso+GzQvV2maYePMAWdmrzqSNZhUpPj3CGw12aGj57I026PgLCTu8CGg==",
+            "dev": true,
             "optional": true
         },
         "@rollup/rollup-win32-x64-msvc": {
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.14.1.tgz",
             "integrity": "sha512-wQGI+LY/Py20zdUPq+XCem7JcPOyzIJBm3dli+56DJsQOHbnXZFEwgmnC6el1TPAfC8lBT3m+z69RmLykNUbew==",
+            "dev": true,
             "optional": true
         },
         "@sinclair/typebox": {
@@ -10089,7 +10122,8 @@
         "@types/estree": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+            "dev": true
         },
         "@types/graceful-fs": {
             "version": "4.1.6",
@@ -11826,6 +11860,7 @@
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
             "optional": true
         },
         "fstream": {
@@ -14692,6 +14727,7 @@
             "version": "4.14.1",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.14.1.tgz",
             "integrity": "sha512-4LnHSdd3QK2pa1J6dFbfm1HN0D7vSK/ZuZTsdyUAlA6Rr1yTouUTL13HaDOGJVgby461AhrNGBS7sCGXXtT+SA==",
+            "dev": true,
             "requires": {
                 "@rollup/rollup-android-arm-eabi": "4.14.1",
                 "@rollup/rollup-android-arm64": "4.14.1",

--- a/package.json
+++ b/package.json
@@ -92,11 +92,11 @@
         "node-addon-api": "^7.0.0",
         "prebuild": "^12.0.0",
         "prettier": "^2.8.8",
-        "typescript": "^5.3.2"
+        "typescript": "^5.3.2",
+        "rollup": "^4.14.1"
     },
     "dependencies": {
         "node-domexception": "^2.0.1",
-        "prebuild-install": "^7.0.1",
-        "rollup": "^4.14.1"
+        "prebuild-install": "^7.0.1"
     }
 }


### PR DESCRIPTION
fixes #250

the current version of rollup requires node 18, while the library uses node 16, since its a required dependency, not a dev dependency, it either needs to be downgraded, or moved to dev dependencies as it errors when installing the package with node16