### PR TITLE
fix: import and throw DOMException correctly

### DIFF
--- a/polyfill/RTCPeerConnection.js
+++ b/polyfill/RTCPeerConnection.js
@@ -4,11 +4,11 @@ import RTCDataChannel from './RTCDataChannel.js';
 import RTCIceCandidate from './RTCIceCandidate.js';
 import { RTCDataChannelEvent, RTCPeerConnectionIceEvent } from './Events.js';
 import RTCSctpTransport from './RTCSctpTransport.js';
-import DOMException from 'node-domexception';
+import 'node-domexception';
 
 export default class _RTCPeerConnection extends EventTarget {
     static async generateCertificate() {
-        throw new Error('Not implemented');
+        throw new DOMException('Not implemented');
     }
 
     #peerConnection;
@@ -190,10 +190,6 @@ export default class _RTCPeerConnection extends EventTarget {
 
     get signalingState() {
         return this.#peerConnection.signalingState();
-    }
-
-    static generateCertificate(keygenAlgorithm) {
-        throw new DOMException('Not implemented');
     }
 
     async addIceCandidate(candidate) {

--- a/test/jest-tests/polyfill.test.js
+++ b/test/jest-tests/polyfill.test.js
@@ -1,0 +1,10 @@
+import { expect } from '@jest/globals';
+import polyfill from '../../polyfill/index.js';
+
+describe('polyfill', () => {
+    test('generateCertificate should throw', () => {
+        expect(async () => {
+            await polyfill.RTCPeerConnection.generateCertificate({});
+        }).rejects.toEqual(new DOMException('Not implemented'));
+    });
+});


### PR DESCRIPTION
The `node-domexception` module polyfills the global environment with the DOMExecption constructor but it doesn't export anything, so use a bare import to perform the polyfill then use the global constructor.

Adds a test to prevent regressions and removes the duplicate definition of `generateCertificate`.