### PR TITLE
feat: support current remote description

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -284,6 +284,7 @@ export class PeerConnection {
     setRemoteDescription(sdp: string, type: DescriptionType): void;
     localDescription(): { type: string; sdp: string } | null;
     remoteDescription(): { type: string; sdp: string } | null;
+    currentRemoteDescription(): { type: string; sdp: string } | null;
     addRemoteCandidate(candidate: string, mid: string): void;
     createDataChannel(label: string, config?: DataChannelInitConfig): DataChannel;
     addTrack(media: Video | Audio): Track;

--- a/polyfill/RTCPeerConnection.js
+++ b/polyfill/RTCPeerConnection.js
@@ -165,7 +165,7 @@ export default class _RTCPeerConnection extends EventTarget {
     }
 
     get currentRemoteDescription() {
-        return new RTCSessionDescription(this.#peerConnection.remoteDescription());
+        return new RTCSessionDescription(this.#peerConnection.currentRemoteDescription());
     }
 
     get localDescription() {

--- a/src/peer-connection-wrapper.cpp
+++ b/src/peer-connection-wrapper.cpp
@@ -41,6 +41,7 @@ Napi::Object PeerConnectionWrapper::Init(Napi::Env env, Napi::Object exports)
             InstanceMethod("setRemoteDescription", &PeerConnectionWrapper::setRemoteDescription),
             InstanceMethod("localDescription", &PeerConnectionWrapper::localDescription),
             InstanceMethod("remoteDescription", &PeerConnectionWrapper::remoteDescription),
+            InstanceMethod("currentRemoteDescription", &PeerConnectionWrapper::currentRemoteDescription),
             InstanceMethod("addRemoteCandidate", &PeerConnectionWrapper::addRemoteCandidate),
             InstanceMethod("createDataChannel", &PeerConnectionWrapper::createDataChannel),
             InstanceMethod("addTrack", &PeerConnectionWrapper::addTrack),
@@ -399,6 +400,24 @@ Napi::Value PeerConnectionWrapper::remoteDescription(const Napi::CallbackInfo &i
     Napi::Env env = info.Env();
 
     std::optional<rtc::Description> desc = mRtcPeerConnPtr ? mRtcPeerConnPtr->remoteDescription() : std::nullopt;
+
+    // Return JS null if no description
+    if (!desc.has_value())
+    {
+        return env.Null();
+    }
+
+    Napi::Object obj = Napi::Object::New(env);
+    obj.Set("type", desc->typeString());
+    obj.Set("sdp", desc.value());
+    return obj;
+}
+
+Napi::Value PeerConnectionWrapper::currentRemoteDescription(const Napi::CallbackInfo &info)
+{
+    Napi::Env env = info.Env();
+
+    std::optional<rtc::Description> desc = mRtcPeerConnPtr ? mRtcPeerConnPtr->currentRemoteDescription() : std::nullopt;
 
     // Return JS null if no description
     if (!desc.has_value())

--- a/src/peer-connection-wrapper.h
+++ b/src/peer-connection-wrapper.h
@@ -25,6 +25,7 @@ public:
   void setRemoteDescription(const Napi::CallbackInfo &info);
   Napi::Value localDescription(const Napi::CallbackInfo &info);
   Napi::Value remoteDescription(const Napi::CallbackInfo &info);
+  Napi::Value currentRemoteDescription(const Napi::CallbackInfo &info);
   void addRemoteCandidate(const Napi::CallbackInfo &info);
   Napi::Value createDataChannel(const Napi::CallbackInfo &info);
   Napi::Value addTrack(const Napi::CallbackInfo &info);


### PR DESCRIPTION
Retrieves the current remote description from libdatachannel to get the current state of the connection negotiation instead of returning the previously set remote description.

Depends on: https://github.com/paullouisageneau/libdatachannel/pull/1204
Refs: https://github.com/paullouisageneau/libdatachannel/issues/1166
Refs: https://github.com/paullouisageneau/libdatachannel/issues/1203