### PR TITLE
fix: add types field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "0.9.1",
     "description": "libdatachannel node bindings",
     "type": "module",
+    "types": "./lib/index.d.ts",
     "exports": {
         ".": {
             "import": {


### PR DESCRIPTION
This supports the ts `node` module resolution when importing from the root of the package.