### PR TITLE
fix: export `DescriptionType` enum values

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -63,7 +63,7 @@ export interface RtcConfig {
 }
 
 // Lowercase to match the description type string from libdatachannel
-export const enum DescriptionType {
+export enum DescriptionType {
     Unspec = 'unspec',
     Offer = 'offer',
     Answer = 'answer',

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,3 +41,11 @@ export default {
     ...nodeDataChannel,
     DataChannelStream,
 };
+
+export const DescriptionType = {
+    Unspec: 'unspec',
+    Offer: 'offer',
+    Answer: 'answer',
+    Pranswer: 'pranswer',
+    Rollback: 'rollback',
+};


### PR DESCRIPTION
At compliation time the values of a `const enum` in TS get [changed to numbers](https://stackoverflow.com/questions/56854964/why-is-const-enum-allowed-with-isolatedmodules) which breaks JS APIs that expect the string values.

At runtime anything in a `.d.ts` file is not available, so the solution is to export enum definitions from the `.d.ts` file as a regular `enum` (no `const`) and export the matching values from the implementation file as a plain object.