### PR TITLE
Fixed iceServers urls parsing giving wrong results.

### DIFF
--- a/polyfill/RTCPeerConnection.js
+++ b/polyfill/RTCPeerConnection.js
@@ -55,10 +55,18 @@ export default class _RTCPeerConnection extends EventTarget {
                 if (config.iceServers[i].urls?.some((url) => url == ''))
                     throw exceptions.SyntaxError('IceServers urls cannot be empty');
 
-                // urls should match the regex "stun\:\w*|turn\:\w*|turns\:\w*"
+                // urls should be valid URLs and match the protocols "stun:|turn:|turns:"
                 if (
                     config.iceServers[i].urls?.some(
-                        (url) => !/^(stun:[\w,\.,:]*|turn:[\w,\.,:]*|turns:[\w,\.,:]*)$/.test(url),
+                        (url) => {
+                            try {
+                                const parsedURL = new URL(url)
+
+                                return !/^(stun:|turn:|turns:)$/.test(parsedURL.protocol)
+                            } catch (error) {
+                                return true
+                            }
+                        },
                     )
                 )
                     throw exceptions.SyntaxError('IceServers urls wrong format');


### PR DESCRIPTION
The previous regex would break on URLs containing valid characters, like `-` and search params, which are also valid. This way, we check if the URL is a valid one and then check for a valid protocol.