### PR TITLE
Fix missing GXX env variable in build

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -98,6 +98,7 @@ jobs:
           COMPILER_FLAGS: ${{ matrix.flags }}
           LIBC: ${{ matrix.libc }}
           GCC: ${{ matrix.gcc }}
+          GXX: ${{ matrix.gxx }}
           CI: true
       - name: Test
         run: sudo podman run --rm -v $(pwd):/usr/app/ -e CI=true --platform linux/${{ matrix.arch }} -t ndc-buildroot:${{ matrix.platform }}-${{ matrix.arch }} npm run test


### PR DESCRIPTION
In https://github.com/murat-dogan/node-datachannel/pull/282, I forgot to add the GXX environment variable to the actual compilation step