### PR TITLE
Fix polyfill link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Please check [electron demo](/examples/electron-demo)
 
 WebRTC polyfills to be used for libraries like `simple-peer`.
 
-Please check [here for more](/polyfill)
+Please check [here for more](/src/polyfill#readme)
 
 ### web-platform-tests
 


### PR DESCRIPTION
The old link gave 404, so I fixed it and, and make it go to the readme section directly