### PR TITLE
Fix Module Resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
             },
             "devDependencies": {
                 "@rollup/plugin-esm-shim": "^0.1.7",
+                "@rollup/plugin-replace": "^6.0.1",
                 "@types/jest": "^29.5.12",
                 "@types/node": "^20.6.1",
                 "@typescript-eslint/eslint-plugin": "^7.17.0",
@@ -1481,6 +1482,28 @@
             },
             "peerDependencies": {
                 "rollup": "^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-replace": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.1.tgz",
+            "integrity": "sha512-2sPh9b73dj5IxuMmDAsQWVFT7mR+yoHweBaXG2W/R8vQ+IWZlnaI7BR7J6EguVQUp1hd8Z7XuozpDjEKQAAC2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
             },
             "peerDependenciesMeta": {
                 "rollup": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "homepage": "https://github.com/murat-dogan/node-datachannel#readme",
     "devDependencies": {
         "@rollup/plugin-esm-shim": "^0.1.7",
+        "@rollup/plugin-replace": "^6.0.1",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.6.1",
         "@typescript-eslint/eslint-plugin": "^7.17.0",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,6 +1,7 @@
 import dts from 'rollup-plugin-dts';
 import esbuild from 'rollup-plugin-esbuild';
 import esmShim from '@rollup/plugin-esm-shim';
+import replace from '@rollup/plugin-replace';
 
 const external = (id) => {
   return !/^[./]/.test(id);
@@ -14,7 +15,15 @@ const bundle = (config) => ({
 
 export default [
   bundle({
-    plugins: [esmShim(), esbuild()],
+    plugins: [
+      replace({
+        include: "src/lib/node-datachannel.ts",
+        preventAssignment: true,
+        "require('../../build": "require('../../../build",
+      }),
+      esmShim(),
+      esbuild(),
+    ],
     output: [
       {
         dir: 'dist/esm',

--- a/src/lib/node-datachannel.ts
+++ b/src/lib/node-datachannel.ts
@@ -1,18 +1,2 @@
-let nodeDataChannel;
-
-try {
-    // from dist
-    nodeDataChannel = require('../../../build/Release/node_datachannel.node');
-}
-catch (e) {
-    // If this is not a module not found error, rethrow it
-    if (e.code !== 'MODULE_NOT_FOUND') {
-        throw e;
-    }
-
-    // from src
-    nodeDataChannel = require('../../build/Release/node_datachannel.node');
-}
-
+let nodeDataChannel = require('../../build/Release/node_datachannel.node');
 export default nodeDataChannel;
-


### PR DESCRIPTION
Compiling a single file executable with bun did not work with the current .node module resolution since it relied on try/catch. I added a rollup plugin to replace the path to node_datachannel.node when transpiled to cjs or esm. This makes sure that we always have the correct path instead of guessing and checking.