### PR TITLE
fix: update addIceCandidate arguments

### DIFF
--- a/src/polyfill/RTCPeerConnection.ts
+++ b/src/polyfill/RTCPeerConnection.ts
@@ -282,7 +282,7 @@ export default class RTCPeerConnection extends EventTarget implements globalThis
         return this.#peerConnection.signalingState();
     }
 
-    async addIceCandidate(candidate?: globalThis.RTCIceCandidateInit | RTCIceCandidate): Promise<void> {
+    async addIceCandidate(candidate?: globalThis.RTCIceCandidateInit | null): Promise<void> {
         if (!candidate || !candidate.candidate) {
             return;
         }


### PR DESCRIPTION
The TypeScript types for `RTCPeerConnection.addIceCandidate` says it accepts `RTCIceCandidateInit | null | undefined`, not `RTCIceCandidateInit | RTCIceCandidate | undefined` so accept those types, otherwise the polyfill does not have type overlap with the browser version (`null` is missing) and `tsc` fails to compile.

See:

https://github.com/microsoft/TypeScript/blob/700ee076e515db2ef49d8cf7e4dc4bf70679575c/src/lib/dom.generated.d.ts#L18714