### PR TITLE
fix: convert enums to types

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -47,11 +47,7 @@ export interface ProxyServer {
     password?: string;
 }
 
-export const enum RelayType {
-    TurnUdp = 'TurnUdp',
-    TurnTcp = 'TurnTcp',
-    TurnTls = 'TurnTls',
-}
+export type RelayType = 'TurnUdp' | 'TurnTcp' | 'TurnTls'
 
 export interface IceServer {
     hostname: string;
@@ -80,13 +76,7 @@ export interface RtcConfig {
 }
 
 // Lowercase to match the description type string from libdatachannel
-export enum DescriptionType {
-    Unspec = 'unspec',
-    Offer = 'offer',
-    Answer = 'answer',
-    Pranswer = 'pranswer',
-    Rollback = 'rollback',
-}
+export type DescriptionType = 'unspec' | 'offer' | 'answer' | 'pranswer' | 'rollback'
 
 export type RTCSdpType = 'answer' | 'offer' | 'pranswer' | 'rollback';
 
@@ -118,10 +108,4 @@ export interface SelectedCandidateInfo {
 }
 
 // Must be same as rtc enum class Direction
-export const enum Direction {
-    SendOnly = 'SendOnly',
-    RecvOnly = 'RecvOnly',
-    SendRecv = 'SendRecv',
-    Inactive = 'Inactive',
-    Unknown = 'Unknown',
-}
+export type Direction = 'SendOnly' | 'RecvOnly' | 'SendRecv' | 'Inactive' | 'Unknown'


### PR DESCRIPTION
In #40 enums had `const` added to them.  [const enums](https://www.typescriptlang.org/docs/handbook/enums.html#const-enums) are removed at compile time and replaced with numbers, e.g.:

```ts
const enum MyEnum {
    AValue,
    AnotherValue
}

function fn (arg: MyEnum) {
    console.info(arg)
}

fn(MyEnum.AnotherValue)
```

...compiles to:

```js
function fn(arg) {
  console.info(arg);
}
fn(1 /* AnotherValue */);
```

Here we require strings to be passed to `libdatachannel`, so in #259 we exported objects with values that correspond to the enums so consuming code can import something they can use in `PeerConnection` method invocations, e.g.:

```js
import { DescriptionType, PeerConnection } from 'node-datachannel'

const pc = new PeerConnection()
pc.setLocalDescription(DescriptionType.Offer, {
  // ...
})
```

In #278 the codebase was converted to TypeScript and a non-const enum crept back in.  Now all the enums live in `types.ts` and since #300 all exports from `types.ts` are re-exported from `index.ts`.

Rollup was introduced as part of #278, but if you check the [esm](https://unpkg.com/browse/node-datachannel@0.24.0/dist/esm/lib/) and [cjs](https://unpkg.com/browse/node-datachannel@0.24.0/dist/cjs/lib/) output dirs, `tests.ts` is not being transpiled to `tests.js` (I think because they aren't added to the default export of `lib/index.js` so would not be in the `cjs` version - `types/lib/types.d.ts` is present though, so `tsc` is doing it's job) and the re-export of the exports from `tests.ts` is being removed so enums are broken again at runtime.

The fix here is to give up on enums since they are a constant source of pain for consumers and change them to be types:

```js
import { PeerConnection } from 'node-datachannel'

const pc = new PeerConnection()
pc.setLocalDescription('offer', {
  // ...
})
```