### PR TITLE
fix: prevent RTCDataChannel.close() from blocking the event loop

### DIFF
--- a/src/polyfill/RTCDataChannel.ts
+++ b/src/polyfill/RTCDataChannel.ts
@@ -191,6 +191,8 @@ export default class RTCDataChannel extends EventTarget implements globalThis.RT
 
     close(): void {
         this.#closeRequested = true;
-        this.#dataChannel.close();
+        setImmediate(() => {
+            this.#dataChannel.close();
+        });
     }
 }


### PR DESCRIPTION
The `RTCDataChannel.close()` method now uses `setImmediate` to ensure it runs asynchronously, preventing the `PeerConnection.close()` method from blocking the event loop.

Fixes: #326 