### PR TITLE
fix: resolve types with node10-style moduleResolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,16 @@
     "main": "./dist/cjs/lib/index.cjs",
     "module": "./dist/esm/lib/index.mjs",
     "types": "./dist/types/lib/index.d.ts",
+    "typesVersions": {
+        "*": {
+            "*": [
+                "dist/types/lib/index.d.ts"
+            ],
+            "polyfill": [
+                "dist/types/polyfill/index.d.ts"
+            ]
+        }
+    },
     "exports": {
         ".": {
             "types": "./dist/types/lib/index.d.ts",


### PR DESCRIPTION
Adds a fix to allow resolving types with `tsc`'s older `node10`-style module resolution.