### PR TITLE
fix: do not copy data before sending over datachannel

### DIFF
--- a/src/polyfill/RTCDataChannel.ts
+++ b/src/polyfill/RTCDataChannel.ts
@@ -180,6 +180,8 @@ export default class RTCDataChannel extends EventTarget implements globalThis.RT
                     this.#dataChannel.sendMessageBinary(new Uint8Array(ab));
                 }
             });
+        } else if (data instanceof Uint8Array) {
+            this.#dataChannel.sendMessageBinary(data);
         } else {
             if (process?.versions?.bun) {
                 this.#dataChannel.sendMessageBinary(Buffer.from(data));


### PR DESCRIPTION
The single-arg constructor of `Uint8Array` copies the data from the passed arraylike.

This can impact streaming performance in high traffic environments.

Instead you can use the three-arg constructor or just pass the `Uint8Array` through if the arg satisfies that type.