### PR TITLE
fix: return globalThis types from polyfill

### DIFF
--- a/src/polyfill/Events.ts
+++ b/src/polyfill/Events.ts
@@ -1,33 +1,29 @@
-import RTCDataChannel from './RTCDataChannel';
-import RTCIceCandidate from './RTCIceCandidate';
-
-
 export class RTCPeerConnectionIceEvent extends Event implements globalThis.RTCPeerConnectionIceEvent {
-    #candidate: RTCIceCandidate;
+    #candidate: globalThis.RTCIceCandidate;
 
-    constructor(candidate: RTCIceCandidate) {
+    constructor(candidate: globalThis.RTCIceCandidate) {
         super('icecandidate');
 
         this.#candidate = candidate;
     }
 
-    get candidate(): RTCIceCandidate {
+    get candidate(): globalThis.RTCIceCandidate {
         return this.#candidate;
     }
 }
 
 export class RTCDataChannelEvent extends Event implements globalThis.RTCDataChannelEvent {
-    #channel: RTCDataChannel;
+    #channel: globalThis.RTCDataChannel;
 
     constructor(type: string, eventInitDict: globalThis.RTCDataChannelEventInit) {
         super(type);
 
         if (type && !eventInitDict.channel) throw new TypeError('channel member is required');
 
-        this.#channel = eventInitDict?.channel as RTCDataChannel;
+        this.#channel = eventInitDict?.channel as globalThis.RTCDataChannel;
     }
 
-    get channel(): RTCDataChannel {
+    get channel(): globalThis.RTCDataChannel {
         return this.#channel;
     }
 }

--- a/src/polyfill/RTCDataChannel.ts
+++ b/src/polyfill/RTCDataChannel.ts
@@ -4,7 +4,7 @@ import { DataChannel } from '../lib/index';
 
 export default class RTCDataChannel extends EventTarget implements globalThis.RTCDataChannel {
     #dataChannel: DataChannel;
-    #readyState: RTCDataChannelState;
+    #readyState: globalThis.RTCDataChannelState;
     #bufferedAmountLowThreshold: number;
     #binaryType: BinaryType;
     #maxPacketLifeTime: number | null;
@@ -15,12 +15,12 @@ export default class RTCDataChannel extends EventTarget implements globalThis.RT
     #closeRequested = false;
 
     // events
-    onbufferedamountlow: ((this: RTCDataChannel, ev: Event) => any) | null;
-    onclose: ((this: RTCDataChannel, ev: Event) => any) | null;
-    onclosing: ((this: RTCDataChannel, ev: Event) => any) | null;
-    onerror: ((this: RTCDataChannel, ev: Event) => any) | null;
-    onmessage: ((this: RTCDataChannel, ev: MessageEvent) => any) | null;
-    onopen: ((this: RTCDataChannel, ev: Event) => any) | null;
+    onbufferedamountlow: ((this: globalThis.RTCDataChannel, ev: Event) => any) | null;
+    onclose: ((this: globalThis.RTCDataChannel, ev: Event) => any) | null;
+    onclosing: ((this: globalThis.RTCDataChannel, ev: Event) => any) | null;
+    onerror: ((this: globalThis.RTCDataChannel, ev: Event) => any) | null;
+    onmessage: ((this: globalThis.RTCDataChannel, ev: MessageEvent) => any) | null;
+    onopen: ((this: globalThis.RTCDataChannel, ev: Event) => any) | null;
 
     constructor(dataChannel: DataChannel, opts: globalThis.RTCDataChannelInit = {}) {
         super();

--- a/src/polyfill/RTCDtlsTransport.ts
+++ b/src/polyfill/RTCDtlsTransport.ts
@@ -1,15 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import RTCIceTransport from './RTCIceTransport';
-import RTCPeerConnection from './RTCPeerConnection';
 
 export default class RTCDtlsTransport extends EventTarget implements globalThis.RTCDtlsTransport {
-    #pc: RTCPeerConnection = null;
+    #pc: globalThis.RTCPeerConnection = null;
     #iceTransport = null;
 
-    onstatechange: ((this: RTCDtlsTransport, ev: Event) => any) | null = null;
-    onerror: ((this: RTCDtlsTransport, ev: Event) => any) | null = null;
+    onstatechange: ((this: globalThis.RTCDtlsTransport, ev: Event) => any) | null = null;
+    onerror: ((this: globalThis.RTCDtlsTransport, ev: Event) => any) | null = null;
 
-    constructor(init: { pc: RTCPeerConnection, extraFunctions }) {
+    constructor(init: { pc: globalThis.RTCPeerConnection, extraFunctions }) {
         super();
         this.#pc = init.pc;
 
@@ -26,11 +25,11 @@ export default class RTCDtlsTransport extends EventTarget implements globalThis.
         });
     }
 
-    get iceTransport(): RTCIceTransport {
+    get iceTransport(): globalThis.RTCIceTransport {
         return this.#iceTransport;
     }
 
-    get state(): RTCDtlsTransportState {
+    get state(): globalThis.RTCDtlsTransportState {
         // reduce state from new, connecting, connected, disconnected, failed, closed, unknown
         // to RTCDtlsTRansport states new, connecting, connected, closed, failed
         let state = this.#pc ? this.#pc.connectionState : 'new';

--- a/src/polyfill/RTCError.ts
+++ b/src/polyfill/RTCError.ts
@@ -1,5 +1,5 @@
 export default class RTCError extends DOMException implements globalThis.RTCError {
-    #errorDetail: RTCErrorDetailType;
+    #errorDetail: globalThis.RTCErrorDetailType;
     #receivedAlert: number | null;
     #sctpCauseCode: number | null;
     #sdpLineNumber: number | null;

--- a/src/polyfill/RTCIceTransport.ts
+++ b/src/polyfill/RTCIceTransport.ts
@@ -1,16 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import RTCIceCandidate from './RTCIceCandidate';
-import RTCPeerConnection from './RTCPeerConnection';
 
 export default class RTCIceTransport extends EventTarget implements globalThis.RTCIceTransport {
-    #pc: RTCPeerConnection = null;
+    #pc: globalThis.RTCPeerConnection = null;
     #extraFunctions = null;
 
-    ongatheringstatechange: ((this: RTCIceTransport, ev: Event) => any) | null = null;
-    onselectedcandidatepairchange: ((this: RTCIceTransport, ev: Event) => any) | null = null;
-    onstatechange: ((this: RTCIceTransport, ev: Event) => any) | null = null;
+    ongatheringstatechange: ((this: globalThis.RTCIceTransport, ev: Event) => any) | null = null;
+    onselectedcandidatepairchange: ((this: globalThis.RTCIceTransport, ev: Event) => any) | null = null;
+    onstatechange: ((this: globalThis.RTCIceTransport, ev: Event) => any) | null = null;
 
-    constructor(init: { pc: RTCPeerConnection, extraFunctions }) {
+    constructor(init: { pc: globalThis.RTCPeerConnection, extraFunctions }) {
         super();
         this.#pc = init.pc;
         this.#extraFunctions = init.extraFunctions;
@@ -50,7 +49,7 @@ export default class RTCIceTransport extends EventTarget implements globalThis.R
         return this.#pc ? this.#pc.iceConnectionState : 'new';
     }
 
-    getLocalCandidates(): RTCIceCandidate[] {
+    getLocalCandidates(): globalThis.RTCIceCandidate[] {
         return this.#pc ? this.#extraFunctions.localCandidates() : [];
     }
 
@@ -58,7 +57,7 @@ export default class RTCIceTransport extends EventTarget implements globalThis.R
         /** */
     }
 
-    getRemoteCandidates(): RTCIceCandidate[] {
+    getRemoteCandidates(): globalThis.RTCIceCandidate[] {
         return this.#pc ? this.#extraFunctions.remoteCandidates() : [];
     }
 

--- a/src/polyfill/RTCPeerConnection.ts
+++ b/src/polyfill/RTCPeerConnection.ts
@@ -23,27 +23,27 @@ export default class RTCPeerConnection extends EventTarget implements globalThis
     #peerConnection: PeerConnection;
     #localOffer: any;
     #localAnswer: any;
-    #dataChannels: Set<RTCDataChannel>;
+    #dataChannels: Set<globalThis.RTCDataChannel>;
     #dataChannelsClosed = 0;
-    #config: RTCConfiguration;
+    #config: globalThis.RTCConfiguration;
     #canTrickleIceCandidates: boolean | null;
-    #sctp: RTCSctpTransport;
+    #sctp: globalThis.RTCSctpTransport;
 
-    #localCandidates: RTCIceCandidate[] = [];
-    #remoteCandidates: RTCIceCandidate[] = [];
+    #localCandidates: globalThis.RTCIceCandidate[] = [];
+    #remoteCandidates: globalThis.RTCIceCandidate[] = [];
 
     // events
-    onconnectionstatechange: ((this: RTCPeerConnection, ev: Event) => any) | null;
-    ondatachannel: ((this: RTCPeerConnection, ev: RTCDataChannelEvent) => any) | null;
-    onicecandidate: ((this: RTCPeerConnection, ev: RTCPeerConnectionIceEvent) => any) | null;
-    onicecandidateerror: ((this: RTCPeerConnection, ev: Event) => any) | null;
-    oniceconnectionstatechange: ((this: RTCPeerConnection, ev: Event) => any) | null;
-    onicegatheringstatechange: ((this: RTCPeerConnection, ev: Event) => any) | null;
-    onnegotiationneeded: ((this: RTCPeerConnection, ev: Event) => any) | null;
-    onsignalingstatechange: ((this: RTCPeerConnection, ev: Event) => any) | null;
-    ontrack: ((this: RTCPeerConnection, ev: globalThis.RTCTrackEvent) => any) | null;
+    onconnectionstatechange: ((this: globalThis.RTCPeerConnection, ev: Event) => any) | null;
+    ondatachannel: ((this: globalThis.RTCPeerConnection, ev: globalThis.RTCDataChannelEvent) => any) | null;
+    onicecandidate: ((this: globalThis.RTCPeerConnection, ev: globalThis.RTCPeerConnectionIceEvent) => any) | null;
+    onicecandidateerror: ((this: globalThis.RTCPeerConnection, ev: Event) => any) | null;
+    oniceconnectionstatechange: ((this: globalThis.RTCPeerConnection, ev: Event) => any) | null;
+    onicegatheringstatechange: ((this: globalThis.RTCPeerConnection, ev: Event) => any) | null;
+    onnegotiationneeded: ((this: globalThis.RTCPeerConnection, ev: Event) => any) | null;
+    onsignalingstatechange: ((this: globalThis.RTCPeerConnection, ev: Event) => any) | null;
+    ontrack: ((this: globalThis.RTCPeerConnection, ev: globalThis.RTCTrackEvent) => any) | null;
 
-    private _checkConfiguration(config: RTCConfiguration): void {
+    private _checkConfiguration(config: globalThis.RTCConfiguration): void {
         if (config && config.iceServers === undefined) config.iceServers = [];
         if (config && config.iceTransportPolicy === undefined) config.iceTransportPolicy = 'all';
 
@@ -103,7 +103,7 @@ export default class RTCPeerConnection extends EventTarget implements globalThis
             throw new TypeError('IceTransportPolicy must be either "all" or "relay"');
     }
 
-    setConfiguration(config: RTCConfiguration): void {
+    setConfiguration(config: globalThis.RTCConfiguration): void {
         this._checkConfiguration(config);
         this.#config = config;
     }
@@ -203,10 +203,10 @@ export default class RTCPeerConnection extends EventTarget implements globalThis
             if (this.onicegatheringstatechange) this.onicegatheringstatechange(e);
         });
         this.addEventListener('datachannel', (e) => {
-            if (this.ondatachannel) this.ondatachannel(e as RTCDataChannelEvent);
+            if (this.ondatachannel) this.ondatachannel(e as globalThis.RTCDataChannelEvent);
         });
         this.addEventListener('icecandidate', (e) => {
-            if (this.onicecandidate) this.onicecandidate(e as RTCPeerConnectionIceEvent);
+            if (this.onicecandidate) this.onicecandidate(e as globalThis.RTCPeerConnectionIceEvent);
         });
 
         this.#sctp = new RTCSctpTransport({
@@ -218,10 +218,10 @@ export default class RTCPeerConnection extends EventTarget implements globalThis
                 maxMessageSize: (): number => {
                     return this.#peerConnection.maxMessageSize();
                 },
-                localCandidates: (): RTCIceCandidate[] => {
+                localCandidates: (): globalThis.RTCIceCandidate[] => {
                     return this.#localCandidates;
                 },
-                remoteCandidates: (): RTCIceCandidate[] => {
+                remoteCandidates: (): globalThis.RTCIceCandidate[] => {
                     return this.#remoteCandidates;
                 },
                 selectedCandidatePair: (): { local: SelectedCandidateInfo; remote: SelectedCandidateInfo } | null => {
@@ -251,31 +251,31 @@ export default class RTCPeerConnection extends EventTarget implements globalThis
         return this.#peerConnection.gatheringState();
     }
 
-    get currentLocalDescription(): RTCSessionDescription {
+    get currentLocalDescription(): globalThis.RTCSessionDescription {
         return new RTCSessionDescription(this.#peerConnection.localDescription() as any);
     }
 
-    get currentRemoteDescription(): RTCSessionDescription {
+    get currentRemoteDescription(): globalThis.RTCSessionDescription {
         return new RTCSessionDescription(this.#peerConnection.remoteDescription() as any);
     }
 
-    get localDescription(): RTCSessionDescription {
+    get localDescription(): globalThis.RTCSessionDescription {
         return new RTCSessionDescription(this.#peerConnection.localDescription() as any);
     }
 
-    get pendingLocalDescription(): RTCSessionDescription {
+    get pendingLocalDescription(): globalThis.RTCSessionDescription {
         return new RTCSessionDescription(this.#peerConnection.localDescription() as any);
     }
 
-    get pendingRemoteDescription(): RTCSessionDescription {
+    get pendingRemoteDescription():globalThis.RTCSessionDescription {
         return new RTCSessionDescription(this.#peerConnection.remoteDescription() as any);
     }
 
-    get remoteDescription(): RTCSessionDescription {
+    get remoteDescription(): globalThis.RTCSessionDescription {
         return new RTCSessionDescription(this.#peerConnection.remoteDescription() as any);
     }
 
-    get sctp(): RTCSctpTransport {
+    get sctp(): globalThis.RTCSctpTransport {
         return this.#sctp;
     }
 
@@ -350,7 +350,7 @@ export default class RTCPeerConnection extends EventTarget implements globalThis
     }
 
 
-    createDataChannel(label, opts = {}): RTCDataChannel {
+    createDataChannel(label, opts = {}): globalThis.RTCDataChannel {
         const channel = this.#peerConnection.createDataChannel(label, opts);
         const dataChannel = new RTCDataChannel(channel, opts);
 

--- a/src/polyfill/RTCSctpTransport.ts
+++ b/src/polyfill/RTCSctpTransport.ts
@@ -1,15 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import RTCDtlsTransport from './RTCDtlsTransport';
-import RTCPeerConnection from './RTCPeerConnection';
 
 export default class RTCSctpTransport extends EventTarget implements globalThis.RTCSctpTransport {
-    #pc: RTCPeerConnection = null;
+    #pc: globalThis.RTCPeerConnection = null;
     #extraFunctions = null;
-    #transport: RTCDtlsTransport = null;
+    #transport: globalThis.RTCDtlsTransport = null;
 
-    onstatechange: ((this: RTCSctpTransport, ev: Event) => any) | null = null;
+    onstatechange: ((this: globalThis.RTCSctpTransport, ev: Event) => any) | null = null;
 
-    constructor(initial: { pc: RTCPeerConnection, extraFunctions }) {
+    constructor(initial: { pc: globalThis.RTCPeerConnection, extraFunctions }) {
         super();
         this.#pc = initial.pc;
         this.#extraFunctions = initial.extraFunctions;
@@ -49,7 +48,7 @@ export default class RTCSctpTransport extends EventTarget implements globalThis.
         return state;
     }
 
-    get transport(): RTCDtlsTransport {
+    get transport(): globalThis.RTCDtlsTransport {
         return this.#transport;
     }
 }

--- a/test/jest-tests/polyfill.test.ts
+++ b/test/jest-tests/polyfill.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect, jest } from '@jest/globals';
-import { RTCPeerConnection, RTCDataChannel } from '../../src/polyfill/index';
+import { RTCPeerConnection } from '../../src/polyfill/index';
 import { PeerConnection } from '../../src/lib/index';
 
 describe('polyfill', () => {
@@ -45,7 +45,7 @@ describe('polyfill', () => {
 			let dc2: RTCDataChannel = null;
 
 			// Creates a fixed binary data for testing
-			function createBinaryTestData(): Uint8Array {
+			function createBinaryTestData(): ArrayBufferView {
 				const binaryData = new Uint8Array(17);
 				const dv = new DataView(binaryData.buffer);
 				dv.setInt8(0, 123);
@@ -143,7 +143,12 @@ describe('polyfill', () => {
                 }
 
 				// Send the test message
-				dc1.send(current.data);
+				// workaround for https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1973
+				if (typeof current.data === 'string') {
+					dc1.send(current.data);
+				} else {
+					dc1.send(current.data);
+				}
 			}
 
 			// Set Callbacks

--- a/test/jest-tests/polyfill.test.ts
+++ b/test/jest-tests/polyfill.test.ts
@@ -13,6 +13,12 @@ describe('polyfill', () => {
 		}).rejects.toEqual(new DOMException('Not implemented'));
 	});
 
+	test('can assign polyfill to global type', () => {
+		// complication check to ensure the interface is implemented correctly
+		const pc: globalThis.RTCPeerConnection = new RTCPeerConnection()
+		expect(pc).toBeTruthy()
+	})
+
 	test('P2P Test', () => {
 		return new Promise<void>((done) => {
 			// Mocks


### PR DESCRIPTION
This is being done in a few places so this PR just tidies up the remaining bits.

Without this you can't assign a `RTCPeerConnection` (e.g. in instance of the polyfill object) to a variable of type `globalThis.RTCPeerConnection` as several fields are present in the polyfill but missing in the DOM type, or the function args are for the polyfill types which again can't be assigned to DOM types due to extra fields/methods.