### PR TITLE
fix: memoize RTCDataChannel fields

### DIFF
--- a/src/polyfill/RTCDataChannel.ts
+++ b/src/polyfill/RTCDataChannel.ts
@@ -11,6 +11,9 @@ export default class RTCDataChannel extends EventTarget implements globalThis.RT
     #maxRetransmits: number | null;
     #negotiated: boolean;
     #ordered: boolean;
+    #id: number
+    #label: string
+    #protocol: string
 
     #closeRequested = false;
 
@@ -33,6 +36,9 @@ export default class RTCDataChannel extends EventTarget implements globalThis.RT
         this.#maxRetransmits = opts.maxRetransmits || null;
         this.#negotiated = opts.negotiated || false;
         this.#ordered = opts.ordered || true;
+        this.#id = this.#dataChannel.getId();
+        this.#label = this.#dataChannel.getLabel();
+        this.#protocol = this.#dataChannel.getProtocol();
 
         // forward dataChannel events
         this.#dataChannel.onOpen(() => {
@@ -131,11 +137,11 @@ export default class RTCDataChannel extends EventTarget implements globalThis.RT
     }
 
     get id(): number | null {
-        return this.#dataChannel.getId();
+        return this.#id;
     }
 
     get label(): string {
-        return this.#dataChannel.getLabel();
+        return this.#label;
     }
 
     get maxPacketLifeTime(): number | null {
@@ -155,7 +161,7 @@ export default class RTCDataChannel extends EventTarget implements globalThis.RT
     }
 
     get protocol(): string {
-        return this.#dataChannel.getProtocol();
+        return this.#protocol
     }
 
     get readyState(): globalThis.RTCDataChannelState {

--- a/test/fixtures/event-promise.ts
+++ b/test/fixtures/event-promise.ts
@@ -1,0 +1,15 @@
+export interface EventPromiseOptions {
+  errorEvent?: string
+}
+
+export async function eventPromise <T = unknown> (emitter: EventTarget, event: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    emitter.addEventListener(event, (evt: any) => {
+      resolve(evt);
+    });
+    emitter.addEventListener('error', (err) => {
+      reject(err);
+    });
+  });
+}


### PR DESCRIPTION
Stores local copies of the id, label and protocol fields for RTCDataChannel polyfill objects.

This is because libdatachannel throws if these fields are accessed on a DataChannel after it's been closed, but browsers allow access so brings the polyfill in line with other implementations.