### PR TITLE
fix: CMake 3.21 or higher is required on Github Workflow

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -28,7 +28,7 @@ jobs:
             gxx: clang++
           - platform: debian
             triple: linux-gnu
-            version: bullseye
+            version: bookworm
             # libc intentionally not set (prebuild requirement)
 
           # Arch-specific baselines


### PR DESCRIPTION
Fixes the following error when building on Debian with Github Actions:
```
CMake Error at build/_deps/libdatachannel-src/deps/libsrtp/CMakeLists.txt:1 (cmake_minimum_required):
CMake 3.21 or higher is required.  You are running version 3.18.4
```