### PR TITLE
fix: use global RTCDataChannelEvent type

### DIFF
--- a/src/polyfill/RTCPeerConnection.ts
+++ b/src/polyfill/RTCPeerConnection.ts
@@ -36,7 +36,7 @@ export default class RTCPeerConnection extends EventTarget implements globalThis
   // events
   onconnectionstatechange: globalThis.RTCPeerConnection['onconnectionstatechange'] = null;
   // For ondatachannel we need to define type manually
-  ondatachannel: ((this: globalThis.RTCPeerConnection, ev: RTCDataChannelEvent) => any) | null;
+  ondatachannel: ((this: globalThis.RTCPeerConnection, ev: globalThis.RTCDataChannelEvent) => any) | null;
   onicecandidate: globalThis.RTCPeerConnection['onicecandidate'] = null;
   onicecandidateerror: globalThis.RTCPeerConnection['onicecandidateerror'] = null;
   oniceconnectionstatechange: globalThis.RTCPeerConnection['oniceconnectionstatechange'] = null;


### PR DESCRIPTION
Use the global `RTCDataChannelEvent` type, not the polyfill otherwise the `RTCPeerConnection` polyfill is not compatible with the global `RTCPeerConnection` type since the `RTCDataChannelEvent` polyfill has a `#private` field that's not on the global `RTCDataChannelEvent` type.

Fixes errors like:

```
error TS2322: Type 'DirectRTCPeerConnection' is not assignable to type 'RTCPeerConnection'.
  Types of property 'ondatachannel' are incompatible.
    Type '((this: RTCPeerConnection, ev: import("/Users/alex/Documents/Workspaces/libp2p/js-libp2p/node_modules/node-datachannel/dist/types/polyfill/Events").RTCDataChannelEvent) => any) | null' is not assignable to type '((this: RTCPeerConnection, ev: RTCDataChannelEvent) => any) | null'.
      Type '(this: RTCPeerConnection, ev: import("/Users/alex/Documents/Workspaces/libp2p/js-libp2p/node_modules/node-datachannel/dist/types/polyfill/Events").RTCDataChannelEvent) => any' is not assignable to type '(this: RTCPeerConnection, ev: RTCDataChannelEvent) => any'.
        Types of parameters 'ev' and 'ev' are incompatible.
          Property '#private' is missing in type 'RTCDataChannelEvent' but required in type 'import("/Users/alex/Documents/Workspaces/libp2p/js-libp2p/node_modules/node-datachannel/dist/types/polyfill/Events").RTCDataChannelEvent'.
```

Related: https://github.com/murat-dogan/node-datachannel/pull/346