### PR TITLE
test: mixed message types should be sent in order

### DIFF
--- a/test/fixtures/connect.ts
+++ b/test/fixtures/connect.ts
@@ -1,0 +1,26 @@
+import { eventPromise } from './event-promise';
+
+export async function connect (peer1: RTCPeerConnection, peer2: RTCPeerConnection): Promise<void> {
+  const dc: RTCDataChannel = peer1.createDataChannel('');
+
+  // Actions
+  const peer1Offer = await peer1.createOffer();
+  await peer2.setRemoteDescription(peer1Offer);
+
+  const peer2Answer = await peer2.createAnswer();
+  await peer1.setRemoteDescription(peer2Answer);
+
+  peer1.addEventListener('icecandidate', (e: RTCPeerConnectionIceEvent) => {
+    peer2.addIceCandidate(e.candidate);
+  });
+
+  peer2.addEventListener('icecandidate', (e: RTCPeerConnectionIceEvent) => {
+    peer1.addIceCandidate(e.candidate);
+  });
+
+  await eventPromise(dc, 'open');
+
+  dc.close();
+
+  await eventPromise(dc, 'close');
+}


### PR DESCRIPTION
Resolving blob content is done asynchronously so if two messages are sent synchronously where the first is a blob and the second is not a blob, the second message will get passed off to libdatachannel first.