### PR TITLE
test: receive lots of data

### DIFF
--- a/test/fixtures/connect.ts
+++ b/test/fixtures/connect.ts
@@ -1,0 +1,26 @@
+import { eventPromise } from './event-promise';
+
+export async function connect (peer1: RTCPeerConnection, peer2: RTCPeerConnection): Promise<void> {
+  const dc: RTCDataChannel = peer1.createDataChannel('');
+
+  // Actions
+  const peer1Offer = await peer1.createOffer();
+  await peer2.setRemoteDescription(peer1Offer);
+
+  const peer2Answer = await peer2.createAnswer();
+  await peer1.setRemoteDescription(peer2Answer);
+
+  peer1.addEventListener('icecandidate', (e: RTCPeerConnectionIceEvent) => {
+    peer2.addIceCandidate(e.candidate);
+  });
+
+  peer2.addEventListener('icecandidate', (e: RTCPeerConnectionIceEvent) => {
+    peer1.addIceCandidate(e.candidate);
+  });
+
+  await eventPromise(dc, 'open');
+
+  dc.close();
+
+  await eventPromise(dc, 'close');
+}


### PR DESCRIPTION
Adds a test that opens a datachannel. When the remote receives notification of the new channel it writes lots of data into it and closes the channel.  The local peer counts the received bytes and asserts that it received them all.

This test currently fails intermittently, largely down to the amount of load the process is under at the time.

You can run similar code in a browser here: https://codepen.io/achingbrain/pen/KwVPZBP?editors=0012

This works in Chrome and Firefox Nightly, though Firefox is quite slow, it takes about 12s for me vs 0.5s for Chrome.