### PR TITLE
Hide all symbols to prevent leakage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,7 @@ endif()
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ${LINK_LIBRARIES})
 
-if(UNIX)
+if(UNIX AND NOT APPLE)
     target_compile_options(${PROJECT_NAME} PRIVATE -fvisibility=hidden -fvisibility-inlines-hidden)
     target_link_options(${PROJECT_NAME} PRIVATE -Wl,--exclude-libs,ALL)
 endif()


### PR DESCRIPTION
Without these flags, the native module leaks a ton of libstdc++ and libdatachannel symbols, conflicting with other native modules that use their own libstdc++ version. Not sure if this is needed on macOS, someone can test and do the same

Before:
```
$ nm -D build/Release/node_datachannel.node | grep ' T '
0000000000276c80 T addr_get_len
0000000000276ce0 T addr_get_port
00000000002770d0 T addr_hash
0000000000276d80 T addr_is_any
0000000000276fa0 T addr_is_equal
0000000000276e50 T addr_is_local
00000000002773a0 T addr_is_numeric_hostname
0000000000276f50 T addr_map_inet6_v4mapped
0000000000277450 T addr_record_hash
0000000000277410 T addr_record_is_equal
0000000000277440 T addr_record_to_string
0000000000277280 T addr_resolve
0000000000276d30 T addr_set_port
0000000000277000 T addr_to_string
0000000000276ef0 T addr_unmap_inet6_v4mapped
000000000027cb80 T agent_add_candidate_pair
000000000027d8c0 T agent_add_candidate_pairs_for_remote
00000000002798b0 T agent_add_local_reflexive_candidate
000000000027cf70 T agent_add_local_relayed_candidate
0000000000279aa0 T agent_add_local_tcp_active_candidate
000000000027dc60 T agent_add_remote_candidate
000000000027de10 T agent_add_remote_reflexive_candidate
0000000000277bc0 T agent_add_turn_server
0000000000279e20 T agent_arm_keepalive
0000000000279b40 T agent_arm_transmission
000000000027a960 T agent_bookkeeping
0000000000277f40 T agent_change_state
0000000000278f30 T agent_channel_send
0000000000277fc0 T agent_conn_fail
000000000027e6a0 T agent_conn_recv
0000000000279c60 T agent_conn_tcp_state
000000000027b4f0 T agent_conn_update
00000000002775d0 T agent_create
0000000000277480 T agent_destroy
0000000000277e80 T agent_direct_send
000000000027dfc0 T agent_dispatch_stun
000000000027c020 T agent_find_entry_from_record
000000000027bf30 T agent_find_entry_from_transaction_id

// a bunch more symbols
```

After:
```
$ nm -D build/Release/node_datachannel.node | grep ' T '
000000000007d1f0 T napi_register_module_v1
000000000007d1e0 T node_api_module_get_api_version_v1
```