### PR TITLE
feat: expose localUfrag on IceUdpMuxRequest

### DIFF
--- a/src/cpp/ice-udp-mux-listener-wrapper.cpp
+++ b/src/cpp/ice-udp-mux-listener-wrapper.cpp
@@ -145,6 +145,7 @@ void IceUdpMuxListenerWrapper::onUnhandledStunRequest(const Napi::CallbackInfo &
           {
         Napi::Object reqObj = Napi::Object::New(env);
         reqObj.Set("ufrag", request.remoteUfrag.c_str());
+        reqObj.Set("localUfrag", request.localUfrag.c_str());
         reqObj.Set("host", request.remoteAddress.c_str());
         reqObj.Set("port", request.remotePort);
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -157,6 +157,7 @@ export type Direction = 'SendOnly' | 'RecvOnly' | 'SendRecv' | 'Inactive' | 'Unk
 
 export interface IceUdpMuxRequest {
   ufrag: string;
+  localUfrag: string;
   host: string;
   port: number;
 }


### PR DESCRIPTION
Passes through `rtc::IceUdpMuxRequest::localUfrag` from libdatachannel to the JS `onUnhandledStunRequest` callback. It was already parsed by libjuice and populated in the C++ struct — the N-API wrapper was just not forwarding it.

Needed by the libp2p WebRTC-Direct v2 transport design (libp2p/specs#715), which encodes per-session state in the first half of the incoming STUN USERNAME — the half that maps to `localUfrag`.

v2 is driven by Chrome's plan to disallow SDP ufrag/pwd munging — the browser-side trick v1 depends on (https://issues.webrtc.org/issues/411871813). This passthrough unblocks server implementations of v2 so libp2p can stop relying on that behaviour.