### PR TITLE
fix: update libdatachannel to v0.24.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ include(FetchContent)
 FetchContent_Declare(
     libdatachannel
     GIT_REPOSITORY https://github.com/paullouisageneau/libdatachannel.git
-    GIT_TAG "v0.24.2"
+    GIT_TAG "v0.24.3"
 )
 
 option(NO_MEDIA "Disable media transport support in libdatachannel" OFF)


### PR DESCRIPTION
## Problem

node-datachannel v0.32.3 pins libdatachannel v0.24.2, which embeds libjuice v1.7.0. In that libjuice version, the non-mux UDP receive loop treats reaching its 1,000-datagram fairness limit as a connection failure.

This is reproducible with js-libp2p's WebRTC-Direct 10 MiB write test on macOS. The ICE connection changes from completed to failed mid-transfer and the echo stream reports an underread.

Upstream libjuice fixed the issue in https://github.com/paullouisageneau/libjuice/commit/f097f19c97abbe3339097d501fe6d3a8762e3ba1.

## Change

Update libdatachannel to v0.24.3, the first release that updates libjuice to v1.7.1 and includes the fix.

The libdatachannel release also contains its other v0.24.3 changes: https://github.com/paullouisageneau/libdatachannel/releases/tag/v0.24.3.

## Verification

- Built the native addon from source on macOS arm64 with Node.js 24.18.0
- npm run lint
- npm test: 5 suites and 11 tests passed
- js-libp2p WebRTC-Direct 10 MiB focused test: 50/50 passed with this build
- Baseline with the existing dependency: 28/30 passed, with two ICE failure underreads

Related js-libp2p CI failure: https://github.com/libp2p/js-libp2p/actions/runs/31764505974/job/94661074278
